### PR TITLE
Fix for name 'url' is not defined error

### DIFF
--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -580,7 +580,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
 
     for child in ob.children:
         dot_scene_node_export( child,
-            url = url, doc = doc, rex = rex,
+            path, doc = doc, rex = rex,
             exported_meshes = exported_meshes,
             meshes = meshes,
             mesh_collision_prims = mesh_collision_prims,

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -20,6 +20,11 @@ def dot_scene(path, scene_name=None):
         scene_name = bpy.context.scene.name
     scene_file = scene_name + '.scene'
     target_scene_file = join(path, scene_file)
+    
+    # Create target path if it does not exist
+    if not os.path.exists(path):
+        print("Creating Directory -", path)
+        os.mkdir(path)
 
     print("Processing Scene -", scene_name)
     prefix = scene_name


### PR DESCRIPTION
I am using blender 2.78b on Gentoo, and am able to use blender2ogre to export a blend file which contains only a mesh.

Once I create an armature (or likely any child objects) the exporter fails with 'url' is not defined.

```
  Processing Materials
      - Exporting root node: Woman
Traceback (most recent call last):
  File "/usr/share/blender/2.78/scripts/addons/io_ogre/ui/export.py", line 78, in execute
    scene.dot_scene(target_path, target_file_name_no_ext)
  File "/usr/share/blender/2.78/scripts/addons/io_ogre/ogre/scene.py", line 150, in dot_scene
    xmlparent = doc._scene_nodes
  File "/usr/share/blender/2.78/scripts/addons/io_ogre/ogre/scene.py", line 583, in dot_scene_node_export
    url = url, doc = doc, rex = rex,
NameError: name 'url' is not defined

location: <unknown location>:-1
```

The offending code (line 583) is
```
        dot_scene_node_export( child,
            url = url, doc = doc, rex = rex,
            exported_meshes = exported_meshes,
            meshes = meshes,
            mesh_collision_prims = mesh_collision_prims,
            mesh_collision_files = mesh_collision_files,
            prefix = prefix,
            objects=objects,
            xmlparent=o
        )
```

The variable url is not set anywhere in scene.py apart from when it is referenced in that line
This is part of a recursive call to dot_scene_node_export, previous calls have used the paramter path.
Setting it to path allows the scene to export correctly.