### PR TITLE
make vertex groups name retrieval more robust

### DIFF
--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -652,7 +652,9 @@ def append_triangle_in_vertex_group(mesh, obj, vertex_groups, ogre_indices, blen
     names = set()
     for v in vertices:
         for g in v.groups:
-            group = obj.vertex_groups[g.group]
+            if g.group >= len(obj.vertex_groups):
+                return
+            group = obj.vertex_groups.get(g.group)
             if not group.name.startswith("ogre.vertex.group."):
                 return
             names.add(group.name)


### PR DESCRIPTION
It might happen that vertices belong to a vertex groups
which do not exist in the object instantiating the mesh.

For instance when importing meshes from another blend file,
used as a mesh library.


Without this commit, I get this error in such a case:
```

Traceback (most recent call last):
  File "/home/sbarthelemy/src/superworktree0/agility/alrobotmodel/libalmodelutils/create_skel.py", line 255, in <module>
    main()
  File "/home/sbarthelemy/src/superworktree0/agility/alrobotmodel/libalmodelutils/create_skel.py", line 239, in main
    EX_reorganiseBuffers=False,
  File "/usr/share/blender/scripts/modules/bpy/ops.py", line 189, in __call__
    ret = op_call(self.idname_py(), None, kw)
RuntimeError: Error: Traceback (most recent call last):
  File "/home/sbarthelemy/.config/blender/2.78/scripts/addons/io_ogre/ui/export.py", line 101, in execute
    scene.dot_scene(target_path, target_file_name_no_ext)
  File "/home/sbarthelemy/.config/blender/2.78/scripts/addons/io_ogre/ogre/scene.py", line 156, in dot_scene
    xmlparent = doc._scene_nodes
  File "/home/sbarthelemy/.config/blender/2.78/scripts/addons/io_ogre/ogre/scene.py", line 463, in dot_scene_node_export
    mesh.dot_mesh(ob, path, overwrite=overwrite)
  File "/home/sbarthelemy/.config/blender/2.78/scripts/addons/io_ogre/ogre/mesh.py", line 230, in dot_mesh
    append_triangle_in_vertex_group(mesh, ob, vertex_groups, face, tri)
  File "/home/sbarthelemy/.config/blender/2.78/scripts/addons/io_ogre/ogre/mesh.py", line 655, in append_triangle_in_vertex_group
    group = obj.vertex_groups[g.group]
IndexError: bpy_prop_collection[index]: index 0 out of range, size 0

location: /usr/share/blender/scripts/modules/bpy/ops.py:189

```
