### PR TITLE
use 'alpha_blend' colour_op in some more cases

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -246,8 +246,11 @@ class OgreMaterialGenerator(object):
             btype = slot.blend_type     # TODO - fix this hack if/when slots support pyRNA
             ex = False; texop = None
             if btype in TEXTURE_COLOUR_OP:
-                if btype=='MIX' and slot.use_map_alpha and not slot.use_stencil:
-                    if slot.diffuse_color_factor >= 1.0: texop = 'alpha_blend'
+                if btype=='MIX' and \
+                    ((slot.use_map_alpha and not slot.use_stencil) or \
+                     (slot.texture.use_alpha and slot.texture.image.use_alpha and not slot.use_map_alpha)):
+                    if slot.diffuse_color_factor >= 1.0:
+                        texop = 'alpha_blend'
                     else:
                         texop = TEXTURE_COLOUR_OP[ btype ]
                         ex = True


### PR DESCRIPTION
The colour_op-choosing heuristic seems brittle, and this commit
does not improve the situation.

Yet, in the few cases I'm concerned with, this patch leads to a better match
between blender and ogre (1.9) rendering.

Notes about this PR:

* I would completely understand if you do not merge this PR (I would not be comfortable merging it myself).

* ideally, there should be an example blender scene with different material/texture combinations, rendered by both blender and ogre.
This could even be converted to a non-regression test, by comparing the renderings with reference ones. (the comparison could be done using [ImageMagick's compare command](https://www.imagemagick.org/script/compare.php)). (Sadly, I currently do not have the time to contribute it myself).
