### PR TITLE
Export custom normals and blend shape normals

### DIFF
--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -37,6 +37,7 @@ _CONFIG_DEFAULTS_ALL = {
     'TOUCH_TEXTURES' : True,
     'ARM_ANIM' : True,
     'SHAPE_ANIM' : True,
+    'SHAPE_NORMALS' : True,
     'ARRAY' : True,
     'MATERIALS' : True,
     'DDS_MIPS' : 16,

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -132,6 +132,8 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
         shared_vertices = {}
         _remap_verts_ = []
+        _remap_normals_ = []
+        _face_indices_ = []
         numverts = 0
         bm = None
 
@@ -172,8 +174,10 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                             nx,ny,nz = swap( n )
                         else:
                             nx,ny,nz = swap( v.normal ) # fixed june 17th 2011
+                            n = mathutils.Vector( [nx, ny, nz] )
                     else:
                         nx,ny,nz = swap( F.normal )
+                        n = mathutils.Vector( [nx, ny, nz] )
 
                     export_vertex_color, color_tuple = \
                             extract_vertex_color(vcolors, vcolors_alpha, F, idx)
@@ -215,6 +219,8 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
                     numverts += 1
                     _remap_verts_.append( v )
+                    _remap_normals_.append( n )
+                    _face_indices_.append( F.index )
 
                     x,y,z = swap(v.co)        # xz-y is correct!
 
@@ -544,19 +550,48 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                         'target' : 'mesh'
                 })
 
+                snormals = None
+                
+                if config.get('SHAPE_NORMALS'):
+                    if smooth:
+                        snormals = skey.normals_vertex_get()
+                    else:
+                        snormals = skey.normals_polygon_get()
+
                 for vidx, v in enumerate(_remap_verts_):
                     pv = skey.data[ v.index ]
                     x,y,z = swap( pv.co - v.co )
+
+                    if config.get('SHAPE_NORMALS'):
+                        n = _remap_normals_[ vidx ]
+                        if smooth:
+                            pn = mathutils.Vector( [snormals[ v.index * 3 ], snormals[ v.index * 3 + 1], snormals[ v.index * 3 + 2]] )
+                        else:
+                            vindex = _face_indices_[ vidx ]
+                            pn = mathutils.Vector( [snormals[ vindex * 3 ], snormals[ vindex * 3 + 1], snormals[ vindex * 3 + 2]] )
+                        nx,ny,nz = swap( pn - n )
+
                     #for i,p in enumerate( skey.data ):
                     #x,y,z = p.co - ob.data.vertices[i].co
                     #x,y,z = swap( ob.data.vertices[i].co - p.co )
                     #if x==.0 and y==.0 and z==.0: continue        # the older exporter optimized this way, is it safe?
-                    doc.leaf_tag('poseoffset', {
-                            'x' : '%6f' % x,
-                            'y' : '%6f' % y,
-                            'z' : '%6f' % z,
-                            'index' : str(vidx)     # is this required?
-                    })
+                    if config.get('SHAPE_NORMALS'):
+                        doc.leaf_tag('poseoffset', {
+                                'x' : '%6f' % x,
+                                'y' : '%6f' % y,
+                                'z' : '%6f' % z,
+                                'nx' : '%6f' % nx,
+                                'ny' : '%6f' % ny,
+                                'nz' : '%6f' % nz,
+                                'index' : str(vidx)     # is this required?
+                        })
+                    else:
+                        doc.leaf_tag('poseoffset', {
+                                'x' : '%6f' % x,
+                                'y' : '%6f' % y,
+                                'z' : '%6f' % z,
+                                'index' : str(vidx)     # is this required?
+                        })
                 doc.end_tag('pose')
             doc.end_tag('poses')
 
@@ -613,6 +648,8 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             del copy
             del mesh
         del _remap_verts_
+        del _remap_normals_
+        del _face_indices_
         del uvcache
         doc.close() # reported by Reyn
         f.close()

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -206,6 +206,10 @@ class _OgreCommonExport_(object):
         name="Shape Animation",
         description="export shape animations - updates the .mesh file",
         default=config.get('SHAPE_ANIM'))
+    EX_SHAPE_NORMALS = BoolProperty(
+        name="Shape Normals",
+        description="export normals in shape animations - updates the .mesh file",
+        default=config.get('SHAPE_NORMALS'))
     EX_TRIM_BONE_WEIGHTS = FloatProperty(
         name="Trim Weights",
         description="ignore bone weights below this value (Ogre supports 4 bones per vertex)",


### PR DESCRIPTION
Export custom normals which could be generated when using a tool such as [yavne](https://github.com/fedackb/yavne).

Optionally export normals for blend shapes.