### PR TITLE
2.80 API.

### DIFF
--- a/io_ogre/console.py
+++ b/io_ogre/console.py
@@ -9,7 +9,8 @@ def export(object_names):
         index = bpy.data.objects.find(name)
         if index != -1:
             obj = bpy.data.objects[index]
-            obj.data.update(calc_tessface=True)
+            obj.data.update()
+            obj.data.calc_loop_triangles()
             export_mesh(obj, '/tmp')
 
 

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -76,7 +76,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
     # blender per default does not calculate these. when querying the quads/tris 
     # of the object blender would crash if calc_tessface was not updated
-    ob.data.update(calc_loop_triangles=True)
+    ob.data.update()
     ob.data.calc_loop_triangles()
 
     Report.meshes.append( obj_name )
@@ -93,7 +93,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             if mod.type in 'ARMATURE ARRAY'.split(): rem.append( mod )
         for mod in rem: copy.modifiers.remove( mod )
         # bake mesh
-        mesh = copy.to_mesh(bpy.context.scene, True, "PREVIEW")    # collaspe
+        mesh = copy.to_mesh()    # collaspe
+        mesh.update()
+        mesh.calc_loop_triangles()
     else:
         copy = ob
         mesh = ob.data
@@ -427,7 +429,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 for level in range(lod_levels+1)[1:]:
                     raise ValueError("No lod please!")
                     decimate.ratio = lod_current_ratio
-                    lod_mesh = ob_copy.to_mesh(scene = bpy.context.scene, apply_modifiers = True, settings = 'PREVIEW')
+                    lod_mesh = ob_copy.to_mesh()
                     ob_copy_meshes.append(lod_mesh)
 
                     # Check min vertice count and that the vertice count got reduced from last iteration
@@ -655,13 +657,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 print('        Done at', timer_diff_str(start), "seconds")
 
         ## Clean up and save
-        #bpy.context.scene.meshes.unlink(mesh)
         if cleanup:
-            #bpy.context.scene.objects.unlink(copy)
             copy.user_clear()
             bpy.data.objects.remove(copy)
-            mesh.user_clear()
-            bpy.data.meshes.remove(mesh)
             del copy
             del mesh
         del _remap_verts_

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -407,7 +407,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
 
     if ob.type == 'MESH':
         # ob.data.tessfaces is empty. always until the following call
-        ob.data.update(calc_loop_triangles=True)
+        ob.data.update()
         ob.data.calc_loop_triangles()
         # if it has no faces at all, the object itself will not be exported, BUT 
         # it might have children

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -71,14 +71,14 @@ class Bone(object):
         self._inverse_total_trans_pose = pose.inverted()
         # calculate difference to parent bone
         if self.parent:
-            pose = self.parent._inverse_total_trans_pose* pose
+            pose = self.parent._inverse_total_trans_pose @ pose
         elif self.fixUpAxis:
-            pose = self.flipMat * pose
+            pose = self.flipMat @ pose
         else:
             pass
 
         self.pose_location =  pose.to_translation() - self.ogre_rest_matrix.to_translation()
-        pose = self.inverse_ogre_rest_matrix * pose
+        pose = self.inverse_ogre_rest_matrix @ pose
         self.pose_rotation = pose.to_quaternion()
 
         #self.pose_location = pbone.location.copy()
@@ -162,12 +162,12 @@ class Bone(object):
         else:
             inverseParentMatrix = mathutils.Matrix(((1,0,0,0),(0,1,0,0),(0,0,1,0),(0,0,0,1)))
 
-        #self.ogre_rest_matrix = self.skeleton.object_space_transformation * self.matrix    # ALLOW ROTATION?
+        #self.ogre_rest_matrix = self.skeleton.object_space_transformation @ self.matrix    # ALLOW ROTATION?
         self.ogre_rest_matrix = self.matrix.copy()
         # store total inverse transformation
         self.inverse_total_trans = self.ogre_rest_matrix.inverted()
         # relative to OGRE parent bone origin
-        self.ogre_rest_matrix = inverseParentMatrix * self.ogre_rest_matrix
+        self.ogre_rest_matrix = inverseParentMatrix @ self.ogre_rest_matrix
         self.inverse_ogre_rest_matrix = self.ogre_rest_matrix.inverted()
 
         # recursion
@@ -305,8 +305,7 @@ class Skeleton(object):
         self.bones = []
         mats = {}
         self.arm = arm = findArmature( ob )
-        arm.hide = False
-        self._restore_layers = list(arm.layers)
+        arm.hide_viewport = False
         #arm.layers = [True]*20      # can not have anything hidden - REQUIRED?
 
         for pbone in arm.pose.bones:

--- a/io_ogre/terrain.py
+++ b/io_ogre/terrain.py
@@ -175,8 +175,8 @@ class OgreCollisionOp(bpy.types.Operator):
         if ob.show_wire:
             ob.show_wire = False
         for child in ob.children:
-            if child.subcollision and not child.hide:
-                child.hide = True
+            if child.subcollision and not child.hide_viewport:
+                child.hide_viewport = True
 
         if mode == 'NONE':
             game.use_ghost = True
@@ -198,7 +198,7 @@ class OgreCollisionOp(bpy.types.Operator):
             game.use_collision_bounds = False
             game.use_collision_compound = True
             proxy = self.get_subcollisions(ob)[0]
-            if proxy.hide: proxy.hide = False
+            if proxy.hide_viewport: proxy.hide_viewport = False
             ob.game.use_collision_compound = True  # proxy
             mod = _get_proxy_decimate_mod( ob )
             mod.show_viewport = True
@@ -213,8 +213,8 @@ class OgreCollisionOp(bpy.types.Operator):
             game.use_collision_bounds = False
             game.use_collision_compound = True
             proxy = self.get_subcollisions(ob)[0]
-            if proxy.hide:
-                proxy.hide = False
+            if proxy.hide_viewport:
+                proxy.hide_viewport = False
         elif mode == 'COMPOUND':
             game.use_ghost = True
             game.use_collision_bounds = False

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -392,7 +392,7 @@ def merge_group( group ):
     for ob in group.objects:
         if ob.type == 'MESH':
             o2 = ob.copy(); copies.append( o2 )
-            o2.data = o2.to_mesh(bpy.context.scene, True, "PREVIEW") # collaspe modifiers
+            o2.data = o2.to_mesh() # collaspe modifiers
             while o2.modifiers:
                 o2.modifiers.remove( o2.modifiers[0] )
             bpy.context.scene.objects.link( o2 ) #; o2.select = True
@@ -411,11 +411,11 @@ def merge_objects( objects, name='_temp_', transform=None ):
         ob.select_set(False)
         if ob.type == 'MESH':
             o2 = ob.copy(); copies.append( o2 )
-            o2.data = o2.to_mesh(bpy.context.scene, True, "PREVIEW") # collaspe modifiers
+            o2.data = o2.to_mesh() # collaspe modifiers
             while o2.modifiers:
                 o2.modifiers.remove( o2.modifiers[0] )
             if transform:
-                o2.matrix_world =  transform * o2.matrix_local
+                o2.matrix_world =  transform @ o2.matrix_local
             bpy.context.scene.objects.link( o2 ) #; o2.select_set(True)
     merged = merge( copies )
     merged.name = name


### PR DESCRIPTION
As per:
https://docs.blender.org/api/current/change_log.html
https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API

. hide renamed to hide_viewport
. update() does not support calc_loop_triangles argument
. to_mesh() arguments changed and returns a temporary owned by the object
. mathutils.Matrix uses @ operator now not *