### PR TITLE
Respect the start & end of frames set by the NLA

### DIFF
--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -444,13 +444,14 @@ class Skeleton(object):
 
                 for strip in nla.strips:
                     action = strip.action
-                    actions[ action.name ] = action
+                    actions[ action.name ] = [action, strip.action_frame_start, strip.action_frame_end]
                     print('   strip name:', strip.name)
                     print('   action name:', action.name)
 
             actionNames = sorted( actions.keys() )  # output actions in alphabetical order
             for actionName in actionNames:
-                action = actions[ actionName ]
+                actionData = actions[ actionName ]
+                action = actionData[0]
                 arm.animation_data.action = action  # set as the current action
                 suppressedBones = []
                 if config.get('ONLY_KEYFRAMED_BONES'):
@@ -462,7 +463,7 @@ class Skeleton(object):
                             # suppress this bone's output
                             b.shouldOutput = False
                             suppressedBones.append( b.name )
-                self.write_animation( arm, actionName, action.frame_range[0], action.frame_range[1], doc, anims )
+                self.write_animation( arm, actionName, actionData[1], actionData[2], doc, anims )
                 # restore suppressed bones
                 for boneName in suppressedBones:
                     bone = self.get_bone( boneName )


### PR DESCRIPTION
instead of assuming the whole action length will be exported
for skeletal animations

Before this PR; the exporter would export the whole range.
For example if "Walk" was 50 frames, it would export 50 frames.

However this is not always desirable, for example I may want to export frames [2; 40] because that's the intended range to achieve a perfect loop.

This brings the exporter to feature parity (in regards to animation) with the old 2.49 exporter which let users manually specify the frame range of the exported action(s)

In order to make use of this feature, one needs to change the "Start Frame" and "End Frame" of "Action Extents" in the NLA editor, and make sure "Sync Length" is turned off

![PR](https://user-images.githubusercontent.com/3395130/74701344-32364700-51e5-11ea-8c39-c32b1e29eb39.png)
