### PR TITLE
textures for 2.80

### DIFF
--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -37,7 +37,7 @@ def dot_scene(path, scene_name=None):
     for ob in bpy.context.scene.objects:
         if ob.subcollision:
             continue
-        if not config.get("EXPORT_HIDDEN") and ob.hide:
+        if not util.should_export(ob):
             continue
         if config.get("SELONLY") and not ob.select_get():
             if ob.type == 'CAMERA' and config.get("FORCE_CAMERA"):
@@ -361,7 +361,7 @@ def ogre_document(materials):
         item.setAttribute('type','material')
         a = doc.createElement('file')
         item.appendChild( a )
-        a.setAttribute('name', material.material_name(mat))
+        a.setAttribute('name', '%s.material'%material.material_name(mat))
 
     # Environ settings
     world = bpy.context.scene.world


### PR DESCRIPTION
Simple image texture export
Image file copy (direct and packed)
Fixes hidden object option

Only tested on Linux.

Changes and question
----------------------
util.py
----------------------
should_export()
	Tells if an object should be exported (uses bpy.context.visible_objects)
	Should we use new visibility modes in 2.80:
		obj.hide_render
		obj.hide_select
		obj.hide_viewport
		
IndentedWriter
	inserts a space before '{'
	removes the extra space at the end of line
	should not break anything

----------------------
ogre/scene.py
----------------------
	Adds ".material" extension to the material file name
	Does not work for me otherwise

----------------------
ogre/material.py
----------------------
Should we keep change_ext ?
generate
	images are collected while generating passes, so the collect action is only made once, as well as the file copy
	is normal map useful ?
	Why was the rotation based on translation.z value ?
		> tried to use the rotation.z value (in radians) instead, but don't know how to use it properly
	Why is projection (SPHERE/FLAT) only used for 'Reflection' coordinates ?
	
copy_textures
	image copy now uses shutil.copy2 to keep metadata, update is made if at least sizes or modification dates are different
	Assuming images are always copied to the target folder with no hierarchy ('TOUCH_TEXTURES' option is not available in the UI), if 2 files have the same name, only one will remain in the export folder
		> use texture name or label instead ?