### PR TITLE
Missing xml to mesh converter as warning, not critical error.

### DIFF
--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -81,12 +81,12 @@ class _OgreCommonExport_(object):
                 layout.prop(self, key)
 
     def execute(self, context):
-        # abort with error otherwise
+        # add warinng about missing XML converter
+        Report.reset()
         if self.converter == "unknown":
-            Report.reset()
-            Report.errors.append("No suitable converter found. Nothing has been exported.")
-            Report.show()
-            return {'FINISHED'}
+            Report.errors.append(
+              "Cannot find suitable OgreXMLConverter or OgreMeshTool executable." +
+              "Export XML mesh - do NOT automatically convert .xml to .mesh file. You MUST run converter mesh manually.")
 
         logger.info("context.blend_data %s"%context.blend_data.filepath)
         logger.info("context.scene.name %s"%context.scene.name)
@@ -133,7 +133,6 @@ class _OgreCommonExport_(object):
         logger.info("target_file_name %s"%target_file_name)
         logger.info("target_file_name_no_ext %s"%target_file_name_no_ext)
 
-        Report.reset()
         scene.dot_scene(target_path, target_file_name_no_ext)
         Report.show()
 

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -68,10 +68,12 @@ def detect_converter_type():
     exe = config.get('OGRETOOLS_XML_CONVERTER')
 
     # extract converter type from its output
-    proc = subprocess.Popen([exe], stdout=subprocess.PIPE)
-    output, _ = proc.communicate()
-
-    output = output.decode('utf-8')
+    try:
+        proc = subprocess.Popen([exe], stdout=subprocess.PIPE)
+        output, _ = proc.communicate()
+        output = output.decode('utf-8')
+    except:
+        output = ""
 
     if output.find("OgreXMLConverter") != -1:
         return "OgreXMLConverter"
@@ -89,8 +91,9 @@ def xml_convert(infile, has_uvs=False):
         version = xml_converter_version()
     elif converter_type == "OgreMeshTool":
         version = mesh_tool_version()
-
-    assert converter_type != "unknown", "Cannot find suitable OgreXMLConverter or OgreMeshTool executable"
+    elif converter_type == "unknown":
+        print("WARNING: Cannot find suitable OgreXMLConverter or OgreMeshTool executable")
+        return
 
     cmd = [exe]
 


### PR DESCRIPTION
Export only XML can be useful in some situation.

This patch:
* fix io_ogre die with traceback (instead of user firendly message) on subprocess exception when can't execute converter
* fix io_ogre die with traceback (instead of user firendly message) on assert when can't detect converter type
* change user firendly report about missing converter from fatal error to non-fatal error in io_ogre/ui/export.py