### PR TITLE
fix zeros normal on some blender mesh

### DIFF
--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -188,13 +188,16 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 v = mesh.vertices[ idx ]
 
                 if smooth:
+                    nx,ny,nz = 0,0,0
                     if mesh.has_custom_normals:
                         n = mathutils.Vector()
                         for loop in bm.verts[idx].link_loops:
                             n += mesh.loops[loop.index].normal
                         n.normalize()
                         nx,ny,nz = swap( n )
-                    else:
+                    # when no custom normals or mesh.loops[...].normal is zero vector
+                    # use normal vector from vertex
+                    if nx == 0 and ny == 0 and nz == 0:
                         nx,ny,nz = swap( v.normal ) # fixed june 17th 2011
                         n = mathutils.Vector( [nx, ny, nz] )
                 elif tangents:
@@ -203,6 +206,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 else:
                     nx,ny,nz = swap( F.normal )
                     n = mathutils.Vector( [nx, ny, nz] )
+
                 if tangents:
                     tx,ty,tz = swap( mesh.loops[ loop_idx ].tangent )
                     tw = mesh.loops[ loop_idx ].bitangent_sign

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -188,16 +188,15 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 v = mesh.vertices[ idx ]
 
                 if smooth:
-                    nx,ny,nz = 0,0,0
+                    n = mathutils.Vector()
                     if mesh.has_custom_normals:
-                        n = mathutils.Vector()
                         for loop in bm.verts[idx].link_loops:
                             n += mesh.loops[loop.index].normal
                         n.normalize()
                         nx,ny,nz = swap( n )
                     # when no custom normals or mesh.loops[...].normal is zero vector
                     # use normal vector from vertex
-                    if nx == 0 and ny == 0 and nz == 0:
+                    if n.length_squared == 0:
                         nx,ny,nz = swap( v.normal ) # fixed june 17th 2011
                         n = mathutils.Vector( [nx, ny, nz] )
                 elif tangents:


### PR DESCRIPTION
When exporting some models from blender 2.83 exported normal vector has value [0,0,0] (in xlm file: `<normal x="0.000000" y="0.000000" z="-0.000000"/>`).
Source of problem is set custom normals flags and zero value of mesh.loops[].normal
This can be fixed by switch on generated tangents, but only for uv mapped verticles.

This patch add check on zero normal vector value and ignore in this case custom normals flags (use normal vector from mesh vertex).