### PR TITLE
Allow use /|?* in material names (but not in filenames)

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -74,7 +74,7 @@ def dot_material(mat, path, **kwargs):
         generator.copy_programs()
     if kwargs.get('touch_textures', config.get('TOUCH_TEXTURES')):
         generator.copy_textures()
-    with open(join(path, generator.material_name + ".material"), 'wb') as fd:
+    with open(join(path, clean_object_name(generator.material_name) + ".material"), 'wb') as fd:
         fd.write(bytes(material_text,'utf-8'))
 
     return generator.material_name
@@ -392,8 +392,8 @@ def material_name( mat, clean = False, prefix='' ):
     clean: deprecated. do not use!
     """
     if type(mat) is str:
-        return prefix + clean_object_name(mat)
-    name = clean_object_name(mat.name)
+        return prefix + clean_object_name(mat, invalid_chars=invalid_chars_in_name)
+    name = clean_object_name(mat.name, invalid_chars=invalid_chars_in_name)
     if mat.library:
         _, filename = split(mat.library.filepath)
         prefix, _ = splitext(filename)

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -52,7 +52,8 @@ def dot_scene(path, scene_name=None):
             # Gather data of invalid names. Don't bother user with warnings on names
             # that only get spaces converted to _, just do that automatically.
             cleanname = clean_object_name(ob.name)
-            cleannamespaces = clean_object_name_with_spaces(ob.name)
+            cleannamespaces = clean_object_name(ob.name, spaces = False)
+            print("ABABA", ob.name)
             if cleanname != ob.name:
                 if cleannamespaces != ob.name:
                     invalidnamewarnings.append(ob.name + " -> " + cleanname)

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -451,17 +451,14 @@ def get_lights_by_type( T ):
             if ob.data.type==T: r.append( ob )
     return r
 
-invalid_chars = '\/:*?"<>|'
+invalid_chars_in_name     = '"<>\:' # "<> is xml prohibited, : is Ogre prohibited, \ is standard escape char
+invalid_chars_in_filename = '/|?*' + invalid_chars_in_name
+invalid_chars_spaces      = ' \t'
 
-def clean_object_name(value):
-    global invalid_chars
-    for invalid_char in invalid_chars:
-        value = value.replace(invalid_char, '_')
-    value = value.replace(' ', '_')
-    return value;
-
-def clean_object_name_with_spaces(value):
-    global invalid_chars
+def clean_object_name(value, invalid_chars = invalid_chars_in_filename, spaces = True):
+    if spaces:
+        invalid_chars += invalid_chars_spaces
+    
     for invalid_char in invalid_chars:
         value = value.replace(invalid_char, '_')
     return value;


### PR DESCRIPTION
Ogre allow use /|?* in material name, so converter should allow this too.

* single, parameterized function for converting objects names - `clean_object_name`
* remove `clean_object_name_with_spaces` - now `clean_object_name(..., spaces = False)`
* clean material names and material filenames in independent calls of clean_object_name (with different invalid chars sets)