### PR TITLE
Add support for add-on script reload

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -35,6 +35,21 @@ import bpy
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
+# https://blender.stackexchange.com/questions/2691/is-there-a-way-to-restart-a-modified-addon
+# https://blender.stackexchange.com/questions/28504/blender-ignores-changes-to-python-scripts/28505
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "properties" in locals():
+        importlib.reload(properties)
+    if "ui" in locals():
+        importlib.reload(ui)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 from . import config
 from . import properties
 from . import ui

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -1,4 +1,24 @@
 import bpy
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    #if "Report" in locals():
+    #    importlib.reload(Report)
+    if "material" in locals():
+        importlib.reload(material)
+    if "export" in locals():
+        importlib.reload(export)
+    if "helper" in locals():
+        importlib.reload(helper)
+    #if "OGREMESH_OT_preview" in locals():
+    #    importlib.reload(OGREMESH_OT_preview)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 from .. import config
 from ..report import Report
 from . import material

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -8,6 +8,23 @@ import logging
 
 from pprint import pprint
 
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "mesh" in locals():
+        importlib.reload(mesh)
+    if "skeleton" in locals():
+        importlib.reload(skeleton)
+    if "scene" in locals():
+        importlib.reload(scene)
+    if "material" in locals():
+        importlib.reload(material)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 from bpy.props import EnumProperty, BoolProperty, FloatProperty, StringProperty, IntProperty
 from .. import config
 from ..report import Report
@@ -27,8 +44,6 @@ def auto_register(register):
         bpy.types.INFO_MT_file_export.append(menu_func)
     else:
         bpy.types.INFO_MT_file_export.remove(menu_func)
-
-
 
 def menu_func(self, context):
     """ invoked when export in drop down menu is clicked """
@@ -94,7 +109,6 @@ class _OgreCommonExport_(object):
         logger.info("context.scene.name %s"%context.scene.name)
         logger.info("self.filepath %s"%self.filepath)
         logger.info("self.last_export_path %s"%self.last_export_path)
-
 
         #-- load addonPreferenc in CONFIG
         config.update_from_addon_preference(context)


### PR DESCRIPTION
When developing for the blender2ogre add-on, eventually it becomes annoying to reload Blender to test the changes made to the script.

Based on the advices from these posts:
[Is there a way to restart a modified addon?](https://blender.stackexchange.com/questions/2691/is-there-a-way-to-restart-a-modified-addon)
[Blender ignores changes to python scripts](https://blender.stackexchange.com/questions/28504/blender-ignores-changes-to-python-scripts/28505)

I implemented a method to be able to reload the add-on from within blender.
