### PR TITLE
Blender 2.9x fixes

### DIFF
--- a/io_ogre/properties.py
+++ b/io_ogre/properties.py
@@ -184,8 +184,9 @@ bpy.types.Material.use_ogre_parent_material = BoolProperty(
     default=False)
 bpy.types.Material.ogre_parent_material = EnumProperty(
     name="Script Inheritence",
-    description='ogre parent material class', #default='NONE',
-    items=[])
+    description='ogre parent material class',
+    items=[ ('none', 'none', 'NONE') ],
+    default='none')
 bpy.types.Material.ogre_polygon_mode = EnumProperty(
     name='faces draw type',
     description="ogre face draw mode",
@@ -210,12 +211,10 @@ bpy.types.Material.ogre_transparent_sorting = EnumProperty(
 bpy.types.Material.ogre_illumination_stage = EnumProperty(
     name='illumination stage',
     description='When using an additive lighting mode (SHADOWTYPE_STENCIL_ADDITIVE or SHADOWTYPE_TEXTURE_ADDITIVE), the scene is rendered in 3 discrete stages, ambient (or pre-lighting), per-light (once per light, with shadowing) and decal (or post-lighting). Usually OGRE figures out how to categorise your passes automatically, but there are some effects you cannot achieve without manually controlling the illumination.',
-    items=[ ('', '', 'autodetect'),
-            ('ambient', 'ambient', 'ambient'),
+    items=[ ('ambient', 'ambient', 'ambient'),
             ('per_light', 'per_light', 'lights'),
             ('decal', 'decal', 'decal') ],
-    default=''
-)
+    default='per_light')
 
 _ogre_depth_func =  [
     ('less_equal', 'less_equal', '<='),

--- a/io_ogre/report.py
+++ b/io_ogre/report.py
@@ -5,7 +5,7 @@ class ReportSingleton(object):
         self.reset()
 
     def show(self):
-        bpy.ops.wm.call_menu( name='MT_mini_report' )
+        bpy.ops.wm.call_menu( name='OGRE_MT_mini_report' )
 
     def reset(self):
         self.materials = []

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -13,9 +13,9 @@ def add_preview_button(self, context):
         op.mesh = True
 
 def auto_register(register):
-    yield HT_toggle_ogre
-    yield OP_interface_toggle
-    yield MT_mini_report
+    yield OGRE_HT_toggle_ogre
+    yield OGRE_OP_interface_toggle
+    yield OGRE_MT_mini_report
     yield OGREMESH_OT_preview
 
     bpy.types.VIEW3D_PT_tools_active.append(add_preview_button)
@@ -24,14 +24,14 @@ def auto_register(register):
     yield from helper.auto_register(register)
 
     if register and config.get('interface_toggle'):
-        OP_interface_toggle.toggle(True)
+        OGRE_OP_interface_toggle.toggle(True)
 
 """
 General purpose ui elements
 """
 
 # FILE | RENDER | ... | OGRE |x| <-- check box
-class OP_interface_toggle(bpy.types.Operator):
+class OGRE_OP_interface_toggle(bpy.types.Operator):
     '''Toggle Ogre UI'''
     bl_idname = "ogre.toggle_interface"
     bl_label = "Ogre UI"
@@ -55,12 +55,12 @@ class OP_interface_toggle(bpy.types.Operator):
         if not show:
             class_func = bpy.utils.unregister_class
 
-        class_func(HT_info_header)
+        class_func(OGRE_HT_info_header)
 
         for clazz in material.ogre_register(show):
             class_func(clazz)
 
-class HT_toggle_ogre(bpy.types.Header):
+class OGRE_HT_toggle_ogre(bpy.types.Header):
     bl_space_type = 'INFO'
 
     def draw(self, context):
@@ -71,7 +71,7 @@ class HT_toggle_ogre(bpy.types.Header):
             icon = 'CHECKBOX_HLT'
         op = layout.operator('ogre.toggle_interface', text='Ogre', icon=icon)
 
-class MT_mini_report(bpy.types.Menu):
+class OGRE_MT_mini_report(bpy.types.Menu):
     bl_label = "Mini-Report | (see console for full report)"
     def draw(self, context):
         layout = self.layout
@@ -79,7 +79,7 @@ class MT_mini_report(bpy.types.Menu):
         for line in txt.splitlines():
             layout.label(text=line)
 
-class HT_info_header(bpy.types.Header):
+class OGRE_HT_info_header(bpy.types.Header):
     bl_space_type = 'INFO'
     def draw(self, context):
         layout = self.layout
@@ -158,6 +158,6 @@ class HT_info_header(bpy.types.Header):
 
             layout.menu( 'MT_preview_material_text', icon='TEXT', text='' )
 
-            layout.menu( "MT_ogre_docs" )
+            layout.menu( "OGRE_MT_ogre_docs" )
             layout.operator("wm.window_fullscreen_toggle", icon='FULLSCREEN_ENTER', text="")
 

--- a/io_ogre/ui/helper.py
+++ b/io_ogre/ui/helper.py
@@ -2,7 +2,7 @@ import bpy
 from ..util import wordwrap
 
 def auto_register(register):
-    yield MT_ogre_docs
+    yield OGRE_MT_ogre_docs
     for clazz in _OGRE_DOCS_:
         yield clazz
 
@@ -13,7 +13,7 @@ def ogredoc( cls ):
     _OGRE_DOCS_.append( cls )
     return cls
 
-class MT_ogre_docs(bpy.types.Menu):
+class OGRE_MT_ogre_docs(bpy.types.Menu):
     bl_label = "Ogre Help"
 
     def draw(self, context):
@@ -23,7 +23,7 @@ class MT_ogre_docs(bpy.types.Menu):
             layout.separator()
         layout.label(text='bug reports to: https://github.com/OGRECave/blender2ogre/issues')
 
-class MT_ogre_helper(bpy.types.Menu):
+class OGRE_MT_ogre_helper(bpy.types.Menu):
     bl_label = '_overloaded_'
 
     def draw(self, context):
@@ -40,7 +40,7 @@ class MT_ogre_helper(bpy.types.Menu):
         layout.separator()
 
 @ogredoc
-class _ogredoc_Installing( MT_ogre_helper ):
+class OGRE_MT_ogredoc_Installing( OGRE_MT_ogre_helper ):
     mydoc = """
 Installing:
     Installing the Addon:
@@ -69,7 +69,7 @@ Installing:
 """
 
 @ogredoc
-class _ogredoc_FAQ( MT_ogre_helper ):
+class OGRE_MT_ogredoc_FAQ( OGRE_MT_ogre_helper ):
     mydoc = """
 
 Q: I have hundres of objects, is there a way i can merge them on export only?
@@ -93,7 +93,7 @@ A: No.
 """
 
 @ogredoc
-class _ogredoc_Animation_System( MT_ogre_helper ):
+class OGRE_MT_ogredoc_Animation_System( OGRE_MT_ogre_helper ):
     mydoc = '''
 Armature Animation System | OgreDotSkeleton
     Quick Start:
@@ -119,7 +119,7 @@ Armature Animation System | OgreDotSkeleton
 '''
 
 @ogredoc
-class _ogredoc_Physics( MT_ogre_helper ):
+class OGRE_MT_ogredoc_Physics( OGRE_MT_ogre_helper ):
     mydoc = '''
 Ogre Dot Scene + BGE Physics
     extended format including external collision mesh, and BGE physics settings
@@ -141,7 +141,7 @@ Blender Collision Setup:
 '''
 
 @ogredoc
-class _ogredoc_Bugs( MT_ogre_helper ):
+class OGRE_MT_ogredoc_Bugs( OGRE_MT_ogre_helper ):
     mydoc = '''
 Known Issues:
     . shape animation breaks when using modifiers that change the vertex count


### PR DESCRIPTION
Two fixes:
- Having Ogre exporter addon enabled breaks Mask Tools 1.6 addon (it's Add Shader produces error due to empty material enum value that Ogre declared in properties.py).
- Use 2.80 class naming conventions to fix warnings.