### PR TITLE
Overhaul logging throughout the export systems

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -116,7 +116,7 @@ class Blender2OgreAddonPreferences(bpy.types.AddonPreferences):
         layout.prop(self, "SHADER_PROGRAMS")      
 
 def register():
-    logging.info('Starting io_ogre %s', bl_info["version"])
+    logging.info(' Starting io_ogre %s', bl_info["version"])
     # the ui modules define auto_register functions that
     # return classes that should be loaded by the plugin
     for clazz in ui.auto_register(True):
@@ -128,7 +128,7 @@ def register():
     config.update_from_addon_preference(bpy.context)
 
 def unregister():
-    logging.info('Unloading io_ogre %s', bl_info["version"])
+    logging.info(' Unloading io_ogre %s', bl_info["version"])
     for clazz in ui.auto_register(False):
         bpy.utils.unregister_class(clazz)
 

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -117,7 +117,6 @@ def load_config():
             with open( CONFIG_FILEPATH, 'rb' ) as f:
                 config_dict = pickle.load( f )
         except:
-            #print('[ERROR]: Can not read config from %s' %CONFIG_FILEPATH)
             logger.error(' Can not read config from %s' % CONFIG_FILEPATH)
 
     for tag in _CONFIG_DEFAULTS_ALL:
@@ -131,7 +130,6 @@ def load_config():
             elif sys.platform.startswith('linux') or sys.platform.startswith('darwin') or sys.platform.startswith('freebsd'):
                 config_dict[ tag ] = _CONFIG_DEFAULTS_UNIX[ tag ]
             else:
-                #print( 'ERROR: unknown platform' )
                 logger.error( ' Unknown platform: %s' % sys.platform)
                 assert 0
 
@@ -144,7 +142,6 @@ def load_config():
             if exe_install_dir != "":
                 # OgreXmlConverter
                 if os.path.isfile(exe_install_dir + "OgreXmlConverter.exe"):
-                    #print ("Using OgreXmlConverter from install path:", exe_install_dir + "OgreXmlConverter.exe")
                     logger.info (" Using OgreXmlConverter from install path: %sOgreXmlConverter.exe" % exe_install_dir)
                     config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXmlConverter.exe"
                 # Run auto updater as silent. Notifies user if there is a new version out.
@@ -154,7 +151,6 @@ def load_config():
                 if os.path.isfile(exe_install_dir + "check-for-updates.exe"):
                     subprocess.Popen([exe_install_dir + "check-for-updates.exe", "/silent"])
     except Exception as e:
-        #print("Exception while reading windows registry:", e)
         logger.error(" Exception while reading windows registry: %s" % e)
 
     # Setup temp hidden RNA to expose the file paths
@@ -191,7 +187,6 @@ def get(name, default=None):
 def update(**kwargs):
     for k,v in kwargs.items():
         if k not in _CONFIG_DEFAULTS_ALL:
-            #print("trying to set CONFIG['%s']=%s, but is not a known config setting" % (k,v))
             logger.warn(" Trying to set CONFIG['%s'] = %s, but it is not a known config setting" % (k,v))
         CONFIG[k] = v
     save_config()
@@ -204,10 +199,8 @@ def save_config():
             with open( CONFIG_FILEPATH, 'wb' ) as f:
                 pickle.dump( CONFIG, f, -1 )
         except:
-            #print('[ERROR]: Can not write to %s' %CONFIG_FILEPATH)
             logger.error(' Can not write to %s' % CONFIG_FILEPATH)
     else:
-        #print('[ERROR:] Config directory does not exist %s' %CONFIG_PATH)
         logger.error(' Config directory %s does not exist' % CONFIG_PATH)
 
 def update_from_addon_preference(context):

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -1,7 +1,8 @@
-
 import bpy, os, sys, logging, pickle, mathutils
 from pprint import pprint
 from bpy.props import *
+
+logger = logging.getLogger('config.py')
 
 AXIS_MODES =  [
     ('xyz', 'xyz', 'no swapping'),
@@ -116,7 +117,8 @@ def load_config():
             with open( CONFIG_FILEPATH, 'rb' ) as f:
                 config_dict = pickle.load( f )
         except:
-            print('[ERROR]: Can not read config from %s' %CONFIG_FILEPATH)
+            #print('[ERROR]: Can not read config from %s' %CONFIG_FILEPATH)
+            logger.error(' Can not read config from %s' % CONFIG_FILEPATH)
 
     for tag in _CONFIG_DEFAULTS_ALL:
         if tag not in config_dict:
@@ -129,7 +131,8 @@ def load_config():
             elif sys.platform.startswith('linux') or sys.platform.startswith('darwin') or sys.platform.startswith('freebsd'):
                 config_dict[ tag ] = _CONFIG_DEFAULTS_UNIX[ tag ]
             else:
-                print( 'ERROR: unknown platform' )
+                #print( 'ERROR: unknown platform' )
+                logger.error( ' Unknown platform: %s' % sys.platform)
                 assert 0
 
     try:
@@ -141,7 +144,8 @@ def load_config():
             if exe_install_dir != "":
                 # OgreXmlConverter
                 if os.path.isfile(exe_install_dir + "OgreXmlConverter.exe"):
-                    print ("Using OgreXmlConverter from install path:", exe_install_dir + "OgreXmlConverter.exe")
+                    #print ("Using OgreXmlConverter from install path:", exe_install_dir + "OgreXmlConverter.exe")
+                    logger.info (" Using OgreXmlConverter from install path: %sOgreXmlConverter.exe" % exe_install_dir)
                     config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXmlConverter.exe"
                 # Run auto updater as silent. Notifies user if there is a new version out.
                 # This will not show any UI if there are no update and will go to network
@@ -150,7 +154,8 @@ def load_config():
                 if os.path.isfile(exe_install_dir + "check-for-updates.exe"):
                     subprocess.Popen([exe_install_dir + "check-for-updates.exe", "/silent"])
     except Exception as e:
-        print("Exception while reading windows registry:", e)
+        #print("Exception while reading windows registry:", e)
+        logger.error(" Exception while reading windows registry: %s" % e)
 
     # Setup temp hidden RNA to expose the file paths
     for tag in _CONFIG_TAGS_:
@@ -186,7 +191,8 @@ def get(name, default=None):
 def update(**kwargs):
     for k,v in kwargs.items():
         if k not in _CONFIG_DEFAULTS_ALL:
-            print("trying to set CONFIG['%s']=%s, but is not a known config setting" % (k,v))
+            #print("trying to set CONFIG['%s']=%s, but is not a known config setting" % (k,v))
+            logger.warn(" Trying to set CONFIG['%s'] = %s, but it is not a known config setting" % (k,v))
         CONFIG[k] = v
     save_config()
 
@@ -198,10 +204,11 @@ def save_config():
             with open( CONFIG_FILEPATH, 'wb' ) as f:
                 pickle.dump( CONFIG, f, -1 )
         except:
-            print('[ERROR]: Can not write to %s' %CONFIG_FILEPATH)
+            #print('[ERROR]: Can not write to %s' %CONFIG_FILEPATH)
+            logger.error(' Can not write to %s' % CONFIG_FILEPATH)
     else:
-        print('[ERROR:] Config directory does not exist %s' %CONFIG_PATH)
-
+        #print('[ERROR:] Config directory does not exist %s' %CONFIG_PATH)
+        logger.error(' Config directory %s does not exist' % CONFIG_PATH)
 
 def update_from_addon_preference(context):
 

--- a/io_ogre/meshy.py
+++ b/io_ogre/meshy.py
@@ -27,7 +27,7 @@ class OGREMESH_OT_preview(bpy.types.Operator):
 
     def execute(self, context):
         Report.reset()
-        Report.messages.append('running %s' %CONFIG['MESH_PREVIEWER'])
+        Report.messages.append('Running "%s"' % CONFIG['MESH_PREVIEWER'])
 
         if sys.platform.startswith('linux') or sys.platform.startswith('darwin') or sys.platform.startswith('freebsd'):
             path = os.path.expanduser("~/io_blender2ogre") # use $HOME so snap can access it

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -87,8 +87,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
     # bake mesh
     mesh = copy.to_mesh(bpy.context.scene, True, "PREVIEW")
 
-    #if logging:
-    #    print('      - Generating:', '%s.mesh.xml' % obj_name)
     logger.info(' * Generating: %s.mesh.xml' % obj_name)
 
     try:
@@ -104,8 +102,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         # Very ugly, have to replace number of vertices later
         doc.start_tag('sharedgeometry', {'vertexcount' : '__TO_BE_REPLACED_VERTEX_COUNT__'})
 
-        #if logging:
-        #    print('      - Writing shared geometry')
         logger.info(' * Writing shared geometry')
 
         # Textures
@@ -142,7 +138,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             if mat:
                 materials.append( (mat_name, extern, mat) )
             else:
-                #print('[WARNING:] Bad material data in', ob)
                 logger.warn(' Bad material data in: %s' % ob.name)
                 materials.append( ('_missing_material_', True, None) ) # fixed dec22, keep proper index
         if not materials:
@@ -292,9 +287,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         doc.end_tag('vertexbuffer')
         doc.end_tag('sharedgeometry')
 
-        #if logging:
-        #    print('        Done at', timer_diff_str(start), "seconds")
-        #    print('      - Writing submeshes')
         logger.info(' - Done at %s seconds' % timer_diff_str(start))
         logger.info(' * Writing submeshes')
 
@@ -370,8 +362,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             idx += 1
         doc.end_tag('submeshnames')
 
-        #if logging:
-        #    print('        Done at', timer_diff_str(start), "seconds")
         logger.info(' - Done at %s seconds' % timer_diff_str(start))
 
         # Generate lod levels
@@ -453,11 +443,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                     # Check min vertice count and that the vertice count got reduced from last iteration
                     lod_mesh_vertices = len(lod_mesh.vertices)
                     if lod_mesh_vertices < lod_min_vertice_count:
-                        #print('        - LOD', level, 'vertice count', lod_mesh_vertices, 'too small. Ignoring LOD.')
                         logger.info(' - LOD level: %s, vertice count: %s too small. Ignoring LOD.' % (level, lod_mesh_vertices))
                         break
                     if lod_mesh_vertices >= lod_current_vertice_count:
-                        #print('        - LOD', level-1, 'vertice count', lod_mesh_vertices, 'cannot be decimated any longer. Ignoring LOD.')
                         logger.info(' - LOD level: %s, vertice count: %s cannot be decimated any longer. Ignoring LOD.' % (level - 1, lod_mesh_vertices))
                         break
                     # todo: should we check if the ratio gets too small? although its up to the user to configure from the export panel
@@ -480,11 +468,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                         'manual'    : "true"
                     })
 
-                    #print('        - Generating', len(lod_generated), 'LOD meshes. Original: vertices', len(mesh.vertices), "faces", len(mesh.tessfaces))
                     logger.info(' - Generating: %s LOD meshes. Original: vertices %s, faces: %s' % (len(lod_generated), len(mesh.vertices), len(mesh.tessfaces)))
                     for lod in lod_generated:
                         ratio_percent = round(lod['ratio'] * 100.0, 0)
-                        #print(' > Writing LOD', lod['level'], 'for distance', lod['distance'], 'and ratio', str(ratio_percent) + "%", 'with', len(lod['mesh'].vertices), 'vertices', len(lod['mesh'].tessfaces), 'faces')
                         logger.info(" > Writing LOD %s for distance %s and ratio %s/100, with %s vertices, %s faces" % (lod['level'], lod['distance'], str(ratio_percent), len(lod['mesh'].vertices), len(lod['mesh'].tessfaces)))
                         lod_ob_temp = bpy.data.objects.new(obj_name, lod['mesh'])
                         lod_ob_temp.data.name = obj_name + '_LOD_' + str(lod['level'])
@@ -516,7 +502,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             ob_copy_meshes = []
 
             if lod_pre_mesh_count != len(bpy.data.meshes):
-                #print('        - WARNING: After LOD generation, cleanup failed to erase all temporary data!')
                 logger.warn(' - After LOD generation, cleanup failed to erase all temporary data!')
 
         arm = ob.find_armature()
@@ -562,11 +547,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                                 })
                                 check += 1
                         else:
-                            #print('WARNING: object vertex groups not in sync with armature', copy, arm, groupIndex)
                             logger.warn(' Mesh: %s vertex groups not in sync with armature %s (groupIndex = %s)' % (mesh.name, arm.name, groupIndex))
                 if check > 4:
                     badverts += 1
-                    #print('WARNING: vertex %s is in more than 4 vertex groups (bone weights)\n(this maybe Ogre incompatible)' %vidx)
                     logger.warn(' <%s> vertex %s is in more than 4 vertex groups (bone weights). This maybe Ogre incompatible' % (mesh.name, vidx))
             if badverts:
                 Report.warnings.append( 'Mesh "%s" has %s vertices weighted to too many bones (Ogre limits a vertex to 4 bones). Try increasing the Trim-Weights threshold option' % (mesh.name, badverts) )
@@ -574,7 +557,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
         # Updated June3 2011 - shape animation works
         if config.get('SHAPE_ANIM') and ob.data.shape_keys and len(ob.data.shape_keys.key_blocks):
-            #print('      - Writing shape keys')
             logger.info(' * Writing shape keys')
 
             doc.start_tag('poses', {})
@@ -584,7 +566,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                     failure = 'FAILED to save shape animation - you can not use a modifier that changes the vertex count! '
                     failure += '[ mesh : %s ]' % mesh.name
                     Report.warnings.append( failure )
-                    #print( failure )
                     logger.error( failure )
                     break
 
@@ -641,13 +622,9 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                 doc.end_tag('pose')
             doc.end_tag('poses')
 
-
-            #if logging:
-            #    print('        Done at', timer_diff_str(start), "seconds")
             logger.info(' - Done at %s seconds' % timer_diff_str(start))
 
             if ob.data.shape_keys.animation_data and len(ob.data.shape_keys.animation_data.nla_tracks):
-                #print('      - Writing shape animations')
                 logger.info(' * Writing shape animations')
                 doc.start_tag('animations', {})
                 _fps = float( bpy.context.scene.render.fps )
@@ -683,7 +660,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                         doc.end_tag('tracks')
                         doc.end_tag('animation')
                 doc.end_tag('animations')
-                #print('        Done at', timer_diff_str(start), "seconds")
                 logger.info(' - Done at %s seconds' % timer_diff_str(start))
 
         ## Clean up and save
@@ -702,8 +678,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         doc.close() # reported by Reyn
         f.close()
 
-        #if logging:
-        #    print('      - Created .mesh.xml at', timer_diff_str(start), "seconds")
         logger.info(' - Created %s.mesh.xml at %s seconds' % (obj_name, timer_diff_str(start)))
 
     # todo: Very ugly, find better way
@@ -730,7 +704,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         if not extern:
             mats.append(mat_name)
         else:
-            #print("extern material", mat_name)
             logger.info(" Extern material: %s" % mat_name)
 
     logger.info(' - Created %s.mesh in total time %s seconds' % (obj_name, timer_diff_str(start)))

--- a/io_ogre/ogre/program.py
+++ b/io_ogre/ogre/program.py
@@ -26,23 +26,18 @@ class OgreProgram(object):
 
     def reload(self): # only one directory is allowed to hold shader programs
         if self.source not in os.listdir( config.get('SHADER_PROGRAMS') ):
-            #print( 'ERROR: ogre material %s is missing source: %s' %(self.name,self.source) )
-            #print( config.get('SHADER_PROGRAMS') )
             logger.error( ' Ogre material %s is missing source: %s' % (self.name,self.source) )
             logger.error( config.get('SHADER_PROGRAMS') )
             return False
         url = os.path.join(  config.get('SHADER_PROGRAMS'), self.source )
-        #print('shader source:', url)
         logger.info(' Shader source: %s' % url)
         self.source_bytes = open( url, 'rb' ).read()#.decode('utf-8')
-        #print('shader source num bytes:', len(self.source_bytes))
         logger.info(' Shader source num bytes: %s' % len(self.source_bytes))
         data = self.source_bytes.decode('utf-8')
 
         for line in data.splitlines():  # only cg shaders use the include macro?
             if line.startswith('#include') and line.count('"')==2:
                 name = line.split()[-1].replace('"','').strip()
-                #print('shader includes:', name)
                 logger.info(' Shader includes: %s' % name)
                 url = os.path.join(  config.get('SHADER_PROGRAMS'), name )
                 self.includes[ name ] = open( url, 'rb' ).read()
@@ -55,7 +50,6 @@ class OgreProgram(object):
         self.includes = {} # cg files may use #include something.cg
 
         if self.name in OgreProgram.PROGRAMS:
-            #print('---copy ogreprogram---', self.name)
             logger.info(' <%s> --- Copy Ogre Program --- ' % self.name)
             other = OgreProgram.PROGRAMS
             self.source = other.source
@@ -68,7 +62,6 @@ class OgreProgram(object):
 
     def parse( self, txt ):
         self.data = txt
-        #print('--parsing ogre shader program--' )
         logger.info(' <%s> -- Parsing Ogre Shader Program-- ' % self.name )
         for line in self.data.splitlines():
             line = line.split('//')[0]

--- a/io_ogre/ogre/program.py
+++ b/io_ogre/ogre/program.py
@@ -1,5 +1,7 @@
-import os
+import os, logging
 from .. import config
+
+logger = logging.getLogger('program.py')
 
 class OgreProgram(object):
     '''
@@ -24,19 +26,24 @@ class OgreProgram(object):
 
     def reload(self): # only one directory is allowed to hold shader programs
         if self.source not in os.listdir( config.get('SHADER_PROGRAMS') ):
-            print( 'ERROR: ogre material %s is missing source: %s' %(self.name,self.source) )
-            print( config.get('SHADER_PROGRAMS') )
+            #print( 'ERROR: ogre material %s is missing source: %s' %(self.name,self.source) )
+            #print( config.get('SHADER_PROGRAMS') )
+            logger.error( ' Ogre material %s is missing source: %s' % (self.name,self.source) )
+            logger.error( config.get('SHADER_PROGRAMS') )
             return False
         url = os.path.join(  config.get('SHADER_PROGRAMS'), self.source )
-        print('shader source:', url)
+        #print('shader source:', url)
+        logger.info(' Shader source: %s' % url)
         self.source_bytes = open( url, 'rb' ).read()#.decode('utf-8')
-        print('shader source num bytes:', len(self.source_bytes))
+        #print('shader source num bytes:', len(self.source_bytes))
+        logger.info(' Shader source num bytes: %s' % len(self.source_bytes))
         data = self.source_bytes.decode('utf-8')
 
         for line in data.splitlines():  # only cg shaders use the include macro?
             if line.startswith('#include') and line.count('"')==2:
                 name = line.split()[-1].replace('"','').strip()
-                print('shader includes:', name)
+                #print('shader includes:', name)
+                logger.info(' Shader includes: %s' % name)
                 url = os.path.join(  config.get('SHADER_PROGRAMS'), name )
                 self.includes[ name ] = open( url, 'rb' ).read()
         return True
@@ -48,7 +55,8 @@ class OgreProgram(object):
         self.includes = {} # cg files may use #include something.cg
 
         if self.name in OgreProgram.PROGRAMS:
-            print('---copy ogreprogram---', self.name)
+            #print('---copy ogreprogram---', self.name)
+            logger.info(' <%s> --- Copy Ogre Program --- ' % self.name)
             other = OgreProgram.PROGRAMS
             self.source = other.source
             self.data = other.data
@@ -60,7 +68,8 @@ class OgreProgram(object):
 
     def parse( self, txt ):
         self.data = txt
-        print('--parsing ogre shader program--' )
+        #print('--parsing ogre shader program--' )
+        logger.info(' <%s> -- Parsing Ogre Shader Program-- ' % self.name )
         for line in self.data.splitlines():
             line = line.split('//')[0]
             line = line.strip()
@@ -70,4 +79,3 @@ class OgreProgram(object):
             elif line.startswith('source'): self.source = line.split()[-1]
             elif line.startswith('entry_point'): self.entry_point = line.split()[-1]
             elif line.startswith('profiles'): self.profiles = line.split()[1:]
-

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -12,6 +12,8 @@ from .material import *
 from . import material
 from .. import bl_info
 
+logger = logging.getLogger('scene.py')
+
 def dot_scene(path, scene_name=None):
     """
     path: string - target path to save the scene file and related files to
@@ -24,10 +26,11 @@ def dot_scene(path, scene_name=None):
 
     # Create target path if it does not exist
     if not os.path.exists(path):
-        print("Creating Directory -", path)
+        print("Creating Directory: ", path)
         os.mkdir(path)
 
-    print("Processing Scene: name:%s, path: %s"%(scene_name, path))
+    #print("Processing Scene -> name: %s, path: %s" % (scene_name, path))
+    logger.info(" * Processing Scene -> name: %s, path: %s" % (scene_name, path))
     prefix = scene_name
 
     # Nodes (objects) - gather because macros will change selection state
@@ -53,7 +56,8 @@ def dot_scene(path, scene_name=None):
             # that only get spaces converted to _, just do that automatically.
             cleanname = clean_object_name(ob.name)
             cleannamespaces = clean_object_name(ob.name, spaces = False)
-            print("ABABA", ob.name)
+            #print("ABABA", ob.name)
+            #logger.info(" ABABA %s" % ob.name)
             if cleanname != ob.name:
                 if cleannamespaces != ob.name:
                     invalidnamewarnings.append(ob.name + " -> " + cleanname)
@@ -61,10 +65,12 @@ def dot_scene(path, scene_name=None):
 
     # Print invalid obj names so user can go and fix them.
     if len(invalidnamewarnings) > 0:
-        print ("[Warning]: Following object names have invalid characters for creating files. They will be automatically converted.")
+        #print ("[Warning]: Following object names have invalid characters for creating files. They will be automatically converted.")
+        logger.warning(" The following object names have invalid characters for creating files. They will be automatically converted.")
         for namewarning in invalidnamewarnings:
-            Report.warnings.append("Auto correcting object name: " + namewarning)
-            print ("  - ", namewarning)
+            Report.warnings.append('Auto corrected Object name: "%s"' % namewarning)
+            #print (" - ", namewarning)
+            logger.warning(" + - %s" % namewarning)
 
     # Linked groups - allows 3 levels of nested blender library linking
     temps = []
@@ -139,7 +145,8 @@ def dot_scene(path, scene_name=None):
 
     materials = []
     if config.get("MATERIALS"):
-        print ("  Processing Materials")
+        #print ("  Processing Materials")
+        logger.info(" * Processing Materials")
         materials = util.objects_merge_materials(meshes)
         dot_materials(materials, path, separate_files=config.get('SEP_MATS'), prefix=prefix)
 
@@ -149,7 +156,8 @@ def dot_scene(path, scene_name=None):
     mesh_collision_files = {}
 
     for root in roots:
-        print('      - Exporting root node:', root.name)
+        #print('      - Exporting root node:', root.name)
+        logger.info(" * Exporting root node: %s " % root.name)
         dot_scene_node_export(root, path = path, doc = doc,
             exported_meshes = exported_meshes,
             meshes = meshes,
@@ -164,7 +172,8 @@ def dot_scene(path, scene_name=None):
         data = doc.toprettyxml()
         with open(target_scene_file, 'wb') as fd:
             fd.write(bytes(data,'utf-8'))
-        print('  Exported Ogre Scene:', target_scene_file)
+        #print('  Exported Ogre Scene:', target_scene_file)
+        logger.info(" - Exported Ogre Scene: %s " % target_scene_file)
 
     for ob in temps:
         bpy.context.scene.objects.unlink( ob )
@@ -211,7 +220,8 @@ class _WrapLogic(object):
                 elif hasattr(attr,'x') and hasattr(attr,'y') and hasattr(attr,'z'):
                     a.setAttribute('value', '%s %s %s' %(attr.x, attr.y, attr.z))
                 else:
-                    print('ERROR: unknown type', attr)
+                    #print('ERROR: unknown type', attr)
+                    logger.error(' Unknown type: %s' % attr)
         return g
 
 class WrapSensor( _WrapLogic ):
@@ -434,11 +444,19 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             collisionPrim = mesh_collision_prims[ ob.data.name ]
         if ob.data.name in mesh_collision_files:
             collisionFile = mesh_collision_files[ ob.data.name ]
+        
+        # Print a warning if there are no UV Maps created for the object
+        # and the user requested to have tangents generated 
+        # (they won't be without a UV Map)
+        if int(config.get("generateTangents")) != 0 and len(ob.data.uv_layers) == 0:
+            #print( "[%s] WARNING: No UV Maps were created for this object, tangents won't be exported." % ob.name )
+            logger.warning(" No UV Maps were created for this object: <%s>, tangents won't be exported." % ob.name)
+            Report.warnings.append( 'Object "%s" has no UV Maps, tangents won\'t be exported.' % ob.name )
 
         e = doc.createElement('entity')
         o.appendChild(e); e.setAttribute('name', ob.name)
         prefix = ''
-        e.setAttribute('meshFile', '%s%s.mesh' %(prefix,clean_object_name(ob.data.name)) )
+        e.setAttribute('meshFile', '%s%s.mesh' % (prefix, clean_object_name(ob.data.name)) )
 
         if not collisionPrim and not collisionFile:
             if ob.game.use_collision_bounds:
@@ -447,11 +465,11 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             else:
                 for child in ob.children:
                     if child.subcollision and child.name.startswith('DECIMATE'):
-                        collisionFile = '%s_collision_%s.mesh' %(prefix,ob.data.name)
+                        collisionFile = '%s_collision_%s.mesh' % (prefix, ob.data.name)
                         break
                 if collisionFile:
                     mesh_collision_files[ ob.data.name ] = collisionFile
-                    mesh.dot_mesh(child, target_path, force_name='%s_collision_%s' % (prefix,ob.data.name) )
+                    mesh.dot_mesh(child, target_path, force_name='%s_collision_%s' % (prefix, ob.data.name) )
                     skeleton.dot_skeleton(child, target_path)
 
         if collisionPrim:
@@ -476,10 +494,14 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         for mod in ob.modifiers:
             if mod.type == 'ARRAY':
                 if mod.fit_type != 'FIXED_COUNT':
-                    print( 'WARNING: Unsupported array-modifier type->', mod.fit_type )
+                    #print( "[%s] WARNING: Unsupported array-modifier type -> %s, only 'FIXED_COUNT' is supported" % (ob.name, mod.fit_type) )
+                    logger.warning(" <%s> Unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
+                    Report.warnings.append("Object \"%s\" has unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
                     continue
                 if not mod.use_constant_offset:
-                    print( 'WARNING: Unsupported array-modifier mode, must be of "constant offset" type' )
+                    #print( "[%s] WARNING: Unsupported array-modifier mode, must be of 'constant offset' type" % ob.name )
+                    logger.warning(" <%s> Unsupported array-modifier mode, must be of 'Constant Offset' type" % ob.name)
+                    Report.warnings.append("Object \"%s\" has unsupported array-modifier mode, must be of 'Constant Offset' type" % ob.name)
                     continue
                 else:
                     #v = ob.matrix_world.to_translation()
@@ -500,8 +522,6 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                     vecs += newvecs
 
         # Deal with Particle Systems
-        print(' *** Deal with Particle Systems ***')
-        
         y_rot = mathutils.Quaternion((0.0, 1.0, 0.0), math.radians(90.0))
 
         for partsys in ob.particle_systems:
@@ -515,12 +535,11 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                     e = doc.createElement('entity')
                     ao.appendChild(e); e.setAttribute('name', ('%s_particle_%s_%s' % (clean_object_name(ob.data.name), index, clean_object_name(dupob.data.name))))
                     e.setAttribute('meshFile', '%s.mesh' % clean_object_name(dupob.data.name))
-                    #print(particle.location)
-                    #print(particle.rotation)
-                    #print(particle.size)
                     index += 1
             else:
-                print( 'WARNING: Particle System %s is not supported for export (should be type: HAIR and render: OBJECT)' )
+                #print( "[%s] WARNING: Particle System %s is not supported for export (should be type: HAIR and render_type: OBJECT)" % (ob.name, partsys.name) )
+                logger.warn(" <%s> Particle System %s is not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
+                Report.warnings.append("Object \"%s\" has Particle System: \"%s\" not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
 
     elif ob.type == 'CAMERA':
         Report.cameras.append( ob.name )

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -29,7 +29,6 @@ def dot_scene(path, scene_name=None):
         print("Creating Directory: ", path)
         os.mkdir(path)
 
-    #print("Processing Scene -> name: %s, path: %s" % (scene_name, path))
     logger.info(" * Processing Scene -> name: %s, path: %s" % (scene_name, path))
     prefix = scene_name
 
@@ -56,8 +55,7 @@ def dot_scene(path, scene_name=None):
             # that only get spaces converted to _, just do that automatically.
             cleanname = clean_object_name(ob.name)
             cleannamespaces = clean_object_name(ob.name, spaces = False)
-            #print("ABABA", ob.name)
-            #logger.info(" ABABA %s" % ob.name)
+            logger.debug(" ABABA %s" % ob.name)
             if cleanname != ob.name:
                 if cleannamespaces != ob.name:
                     invalidnamewarnings.append(ob.name + " -> " + cleanname)
@@ -65,11 +63,9 @@ def dot_scene(path, scene_name=None):
 
     # Print invalid obj names so user can go and fix them.
     if len(invalidnamewarnings) > 0:
-        #print ("[Warning]: Following object names have invalid characters for creating files. They will be automatically converted.")
         logger.warning(" The following object names have invalid characters for creating files. They will be automatically converted.")
         for namewarning in invalidnamewarnings:
             Report.warnings.append('Auto corrected Object name: "%s"' % namewarning)
-            #print (" - ", namewarning)
             logger.warning(" + - %s" % namewarning)
 
     # Linked groups - allows 3 levels of nested blender library linking
@@ -145,7 +141,6 @@ def dot_scene(path, scene_name=None):
 
     materials = []
     if config.get("MATERIALS"):
-        #print ("  Processing Materials")
         logger.info(" * Processing Materials")
         materials = util.objects_merge_materials(meshes)
         dot_materials(materials, path, separate_files=config.get('SEP_MATS'), prefix=prefix)
@@ -156,7 +151,6 @@ def dot_scene(path, scene_name=None):
     mesh_collision_files = {}
 
     for root in roots:
-        #print('      - Exporting root node:', root.name)
         logger.info(" * Exporting root node: %s " % root.name)
         dot_scene_node_export(root, path = path, doc = doc,
             exported_meshes = exported_meshes,
@@ -172,7 +166,6 @@ def dot_scene(path, scene_name=None):
         data = doc.toprettyxml()
         with open(target_scene_file, 'wb') as fd:
             fd.write(bytes(data,'utf-8'))
-        #print('  Exported Ogre Scene:', target_scene_file)
         logger.info(" - Exported Ogre Scene: %s " % target_scene_file)
 
     for ob in temps:
@@ -220,7 +213,6 @@ class _WrapLogic(object):
                 elif hasattr(attr,'x') and hasattr(attr,'y') and hasattr(attr,'z'):
                     a.setAttribute('value', '%s %s %s' %(attr.x, attr.y, attr.z))
                 else:
-                    #print('ERROR: unknown type', attr)
                     logger.error(' Unknown type: %s' % attr)
         return g
 
@@ -449,7 +441,6 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         # and the user requested to have tangents generated 
         # (they won't be without a UV Map)
         if int(config.get("generateTangents")) != 0 and len(ob.data.uv_layers) == 0:
-            #print( "[%s] WARNING: No UV Maps were created for this object, tangents won't be exported." % ob.name )
             logger.warning(" No UV Maps were created for this object: <%s>, tangents won't be exported." % ob.name)
             Report.warnings.append( 'Object "%s" has no UV Maps, tangents won\'t be exported.' % ob.name )
 
@@ -494,12 +485,10 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         for mod in ob.modifiers:
             if mod.type == 'ARRAY':
                 if mod.fit_type != 'FIXED_COUNT':
-                    #print( "[%s] WARNING: Unsupported array-modifier type -> %s, only 'FIXED_COUNT' is supported" % (ob.name, mod.fit_type) )
                     logger.warning(" <%s> Unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
                     Report.warnings.append("Object \"%s\" has unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
                     continue
                 if not mod.use_constant_offset:
-                    #print( "[%s] WARNING: Unsupported array-modifier mode, must be of 'constant offset' type" % ob.name )
                     logger.warning(" <%s> Unsupported array-modifier mode, must be of 'Constant Offset' type" % ob.name)
                     Report.warnings.append("Object \"%s\" has unsupported array-modifier mode, must be of 'Constant Offset' type" % ob.name)
                     continue
@@ -537,7 +526,6 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                     e.setAttribute('meshFile', '%s.mesh' % clean_object_name(dupob.data.name))
                     index += 1
             else:
-                #print( "[%s] WARNING: Particle System %s is not supported for export (should be type: HAIR and render_type: OBJECT)" % (ob.name, partsys.name) )
                 logger.warn(" <%s> Particle System %s is not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
                 Report.warnings.append("Object \"%s\" has Particle System: \"%s\" not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
 

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -49,7 +49,6 @@ class Bone(object):
                 #self.flipMat = mathutils.Matrix(((1,0,0,0),(0,0,1,0),(0,1,0,0),(0,0,0,1)))
                 self.flipMat = mathutils.Matrix(((1,0,0,0),(0,0,1,0),(0,-1,0,0),(0,0,0,1))) # thanks to Waruck
             else:
-                #print( 'ERROR - TODO: axis swap mode not supported with armature animation' )
                 logger.error( ' - TODO: Axis swap mode not supported with armature animation' )
                 assert 0
 
@@ -286,7 +285,6 @@ def findArmature( ob ):
         # search for another armature that is a proxy for it
         for ob2 in bpy.data.objects:
             if ob2.type == 'ARMATURE' and ob2.proxy == arm:
-                #print( "proxy armature %s found" % ob2.name )
                 logger.info( " - Proxy armature %s found" % ob2.name )
                 return ob2
     return arm
@@ -443,14 +441,11 @@ class Skeleton(object):
             # the only thing NLA is used for is to gather the names of the actions
             # it doesn't matter if the actions are all in the same NLA track or in different tracks
             for nla in arm.animation_data.nla_tracks:        # NLA required, lone actions not supported
-                #print('NLA track:',  nla.name)
                 logger.info(' + NLA track: %s' % nla.name)
 
                 for strip in nla.strips:
                     action = strip.action
                     actions[ action.name ] = [action, strip.action_frame_start, strip.action_frame_end]
-                    #print('   strip name:', strip.name)
-                    #print('   action name:', action.name)
                     logger.info('   - Action name: %s' % action.name)
                     logger.info('   -  Strip name: %s' % strip.name)
 

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -1,10 +1,11 @@
-import bpy
-import mathutils
+import bpy, mathutils, logging
 from .. import config
 from ..report import Report
 from ..xml import RDocument
 from .. import util
 from os.path import join
+
+logger = logging.getLogger('skeleton.py')
 
 def dot_skeleton(obj, path, **kwargs):
     """
@@ -48,7 +49,8 @@ class Bone(object):
                 #self.flipMat = mathutils.Matrix(((1,0,0,0),(0,0,1,0),(0,1,0,0),(0,0,0,1)))
                 self.flipMat = mathutils.Matrix(((1,0,0,0),(0,0,1,0),(0,-1,0,0),(0,0,0,1))) # thanks to Waruck
             else:
-                print( 'ERROR - TODO: axis swap mode not supported with armature animation' )
+                #print( 'ERROR - TODO: axis swap mode not supported with armature animation' )
+                logger.error( ' - TODO: Axis swap mode not supported with armature animation' )
                 assert 0
 
         self.skeleton = skeleton
@@ -284,7 +286,8 @@ def findArmature( ob ):
         # search for another armature that is a proxy for it
         for ob2 in bpy.data.objects:
             if ob2.type == 'ARMATURE' and ob2.proxy == arm:
-                print( "proxy armature %s found" % ob2.name )
+                #print( "proxy armature %s found" % ob2.name )
+                logger.info( " - Proxy armature %s found" % ob2.name )
                 return ob2
     return arm
 
@@ -297,9 +300,9 @@ class Skeleton(object):
 
     def __init__(self, ob ):
         if ob.location.x != 0 or ob.location.y != 0 or ob.location.z != 0:
-            Report.warnings.append('ERROR: Mesh (%s): is offset from Armature - zero transform is required' %ob.name)
+            Report.warnings.append('ERROR: Mesh (%s): is offset from Armature - zero transform is required' % ob.name)
         if ob.scale.x != 1 or ob.scale.y != 1 or ob.scale.z != 1:
-            Report.warnings.append('ERROR: Mesh (%s): has been scaled - scale(1,1,1) is required' %ob.name)
+            Report.warnings.append('ERROR: Mesh (%s): has been scaled - scale(1,1,1) is required' % ob.name)
 
         self.object = ob
         self.bones = []
@@ -323,7 +326,7 @@ class Skeleton(object):
         #self.object_space_transformation = e.to_matrix().to_4x4()
         x,y,z = arm.matrix_local.to_euler()
         if x != 0 or y != 0 or z != 0:
-            Report.warnings.append('ERROR: Armature: %s is rotated - (rotation is ignored)' %arm.name)
+            Report.warnings.append('ERROR: Armature: %s is rotated - (rotation is ignored)' % arm.name)
 
         ## setup bones for Ogre format ##
         for b in self.bones:
@@ -434,19 +437,22 @@ class Skeleton(object):
             savedAction = arm.animation_data.action
             arm.animation_data.use_nla = False
             if not len( arm.animation_data.nla_tracks ):
-                Report.warnings.append('you must assign an NLA strip to armature (%s) that defines the start and end frames' %arm.name)
+                Report.warnings.append('You must assign an NLA strip to armature (%s) that defines the start and end frames' % arm.name)
 
             actions = {}  # actions by name
             # the only thing NLA is used for is to gather the names of the actions
             # it doesn't matter if the actions are all in the same NLA track or in different tracks
             for nla in arm.animation_data.nla_tracks:        # NLA required, lone actions not supported
-                print('NLA track:',  nla.name)
+                #print('NLA track:',  nla.name)
+                logger.info(' + NLA track: %s' % nla.name)
 
                 for strip in nla.strips:
                     action = strip.action
                     actions[ action.name ] = [action, strip.action_frame_start, strip.action_frame_end]
-                    print('   strip name:', strip.name)
-                    print('   action name:', action.name)
+                    #print('   strip name:', strip.name)
+                    #print('   action name:', action.name)
+                    logger.info('   - Action name: %s' % action.name)
+                    logger.info('   -  Strip name: %s' % strip.name)
 
             actionNames = sorted( actions.keys() )  # output actions in alphabetical order
             for actionName in actionNames:

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -6,16 +6,16 @@ if "bpy" in locals():
     import importlib
     if "config" in locals():
         importlib.reload(config)
-    #if "Report" in locals():
-    #    importlib.reload(Report)
+    if "report.Report" in locals():
+        importlib.reload(report.Report)
     if "material" in locals():
         importlib.reload(material)
     if "export" in locals():
         importlib.reload(export)
     if "helper" in locals():
         importlib.reload(helper)
-    #if "OGREMESH_OT_preview" in locals():
-    #    importlib.reload(OGREMESH_OT_preview)
+    if "meshy.OGREMESH_OT_preview" in locals():
+        importlib.reload(meshy.OGREMESH_OT_preview)
 
 # This is only relevant on first run, on later reloads those modules
 # are already in locals() and those statements do not do anything.

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -1,10 +1,4 @@
-
-import bpy
-import os
-import getpass
-import math
-import mathutils
-import logging
+import bpy, os, getpass, math, mathutils, logging
 
 from pprint import pprint
 
@@ -35,7 +29,7 @@ from ..ogre import skeleton
 from ..ogre import scene
 from ..ogre import material
 
-logger = logging.getLogger('root')
+logger = logging.getLogger('export.py')
 
 def auto_register(register):
     yield OP_ogre_export
@@ -60,12 +54,11 @@ class _OgreCommonExport_(object):
             return True
 
     def __init__(self):
-        # check that converter is setup
+        # Check that converter is setup
         self.converter = detect_converter_type()
 
     def invoke(self, context, event):
-
-        # update the interface with the config values
+        # Update the interface with the config values
         for key, value in config.CONFIG.items():
             if getattr(self, "EX_" + key, None) or getattr(self, "EX_Vx_" + key, None) or getattr(self, "EX_V1_" + key, None) or getattr(self, "EX_V2_" + key, None):
                 # todo: isn't the key missing the "EX_" prefix?
@@ -98,23 +91,23 @@ class _OgreCommonExport_(object):
                 layout.prop(self, key)
 
     def execute(self, context):
-        # add warinng about missing XML converter
+        # Add warinng about missing XML converter
         Report.reset()
         if self.converter == "unknown":
             Report.errors.append(
               "Cannot find suitable OgreXMLConverter or OgreMeshTool executable." +
               "Export XML mesh - do NOT automatically convert .xml to .mesh file. You MUST run converter mesh manually.")
 
-        logger.info("context.blend_data %s"%context.blend_data.filepath)
-        logger.info("context.scene.name %s"%context.scene.name)
-        logger.info("self.filepath %s"%self.filepath)
-        logger.info("self.last_export_path %s"%self.last_export_path)
+        logger.debug(" Context.blend_data: %s" % context.blend_data.filepath)
+        logger.debug(" Context.scene.name: %s" % context.scene.name)
+        logger.debug(" Self.filepath: %s" % self.filepath)
+        logger.debug(" Self.last_export_path: %s" % self.last_export_path)
 
-        #-- load addonPreferenc in CONFIG
+        # Load addonPreference in CONFIG
         config.update_from_addon_preference(context)
 
-        # Resolve path from opened .blend if available. It's not if
-        # blender normally was opened with "last open scene".
+        # Resolve path from opened .blend if available. 
+        # Normally it's not if blender was opened with "Recover Last Session".
         # After export is done once, remember that path when re-exporting.
         if not self.last_export_path:
             # First export during this blender run
@@ -128,7 +121,7 @@ class _OgreCommonExport_(object):
         if self.filepath == "" or not self.filepath:
             self.filepath = "blender2ogre"
 
-        logger.info("self.filepath %s"%self.filepath)
+        logger.debug(" Self.filepath: %s" % self.filepath)
 
         kw = {}
         for name in dir(_OgreCommonExport_):
@@ -145,9 +138,9 @@ class _OgreCommonExport_(object):
         target_file_name = clean_object_name(target_file_name)
         target_file_name_no_ext = os.path.splitext(target_file_name)[0]
 
-        logger.info("target_path %s"%target_path)
-        logger.info("target_file_name %s"%target_file_name)
-        logger.info("target_file_name_no_ext %s"%target_file_name_no_ext)
+        logger.debug(" Target_path: %s" % target_path)
+        logger.debug(" Target_file_name: %s" % target_file_name)
+        logger.debug(" Target_file_name_no_ext: %s" % target_file_name_no_ext)
 
         scene.dot_scene(target_path, target_file_name_no_ext)
         Report.show()


### PR DESCRIPTION
Logging Overhaul:
- Replaced logging by `logger` which prints the python file name
- Replaced `print()`s by `logger` calls with the corresponding info, warn, error or debug levels
- Consistent logging messages and visual output
- Add more warnings to the final report (the user might not see the log)

This changes also open the way to a logger module with the option to write the log to a file and choose log level (TODO)
