### PR TITLE
Apply improvements from 2.8+ LOD fixes to 2.7x-support

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -1,18 +1,32 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "util" in locals():
+        importlib.reload(util)
+    if "shader" in locals():
+        importlib.reload(shader)
+    if "report" in locals():
+        importlib.reload(report)
+    if "program" in locals():
+        importlib.reload(program)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
+import logging, os, shutil, tempfile
 from datetime import datetime
-import os
+from itertools import chain
 from os.path import join, split, splitext
-from ..util import *
-from .. import util
+from bpy.props import EnumProperty
 from .. import config
 from .. import shader
+from .. import util
 from ..report import Report
-import tempfile
-import shutil
-import logging
-from itertools import chain
-
-from bpy.props import EnumProperty
 from .program import OgreProgram
+from ..util import *
 
 logger = logging.getLogger('material')
 

--- a/io_ogre/ogre/program.py
+++ b/io_ogre/ogre/program.py
@@ -1,3 +1,13 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 import os, logging
 from .. import config
 

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -1,16 +1,38 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "material" in locals():
+        importlib.reload(material)
+    if "mesh" in locals():
+        importlib.reload(mesh)
+    if "skeleton" in locals():
+        importlib.reload(skeleton)
+    if "config" in locals():
+        importlib.reload(config)
+    if "util" in locals():
+        importlib.reload(util)
+    if "report" in locals():
+        importlib.reload(report)
+    if "xml" in locals():
+        importlib.reload(xml)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 import bpy, mathutils, os, getpass, math
 from os.path import join
-from .. import util
-from .. import config
+from . import material
 from . import mesh
 from . import skeleton
+from .. import bl_info
+from .. import config
+from .. import util
 from ..report import Report
 from ..util import *
 from ..xml import *
-from .mesh import *
 from .material import *
-from . import material
-from .. import bl_info
+from .mesh import *
 
 logger = logging.getLogger('scene')
 
@@ -168,8 +190,10 @@ def dot_scene(path, scene_name=None):
             fd.write(bytes(data,'utf-8'))
         logger.info("- Exported Ogre Scene: %s " % target_scene_file)
 
+    # Remove temporal objects
     for ob in temps:
-        bpy.context.scene.objects.unlink( ob )
+        bpy.data.meshes.remove(ob.data)
+        bpy.data.objects.remove(ob)
 
 class _WrapLogic(object):
     SwapName = { 'frame_property' : 'animation' } # custom name hacks

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -1,3 +1,19 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "report" in locals():
+        importlib.reload(report)
+    if "xml" in locals():
+        importlib.reload(xml)
+    if "util" in locals():
+        importlib.reload(util)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 import bpy, mathutils, logging
 from .. import config
 from ..report import Report


### PR DESCRIPTION
 - Apply improvements from 2.8+ LOD fixes to 2.7x-support
 - mesh.py->dot_mesh() was leaving orphan meshes
 - util.py->merge_group() was leaving orphan meshes
 - More script reloading (some modules were not being reloaded)
 - Add progress report from Kenshi exporter
