### PR TITLE
LOD: Give the option to also use OgreMeshUpgrader to generate LODs

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -68,6 +68,12 @@ class Blender2OgreAddonPreferences(bpy.types.AddonPreferences):
         default=config.CONFIG['OGRETOOLS_XML_CONVERTER'],
         update=apply_preferences_to_config
     )
+    OGRETOOLS_MESH_UPGRADER = bpy.props.StringProperty(
+        name="OGRETOOLS_MESH_UPGRADER",
+        subtype='FILE_PATH',
+        default=config.CONFIG['OGRETOOLS_MESH_UPGRADER'],
+        update=apply_preferences_to_config
+    )
     OGRETOOLS_MESH_MAGICK = bpy.props.StringProperty(
         name="OGRETOOLS_MESH_MAGICK",
         subtype='FILE_PATH',
@@ -102,6 +108,7 @@ class Blender2OgreAddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "OGRETOOLS_XML_CONVERTER")
+        layout.prop(self, "OGRETOOLS_MESH_UPGRADER")
         layout.prop(self, "OGRETOOLS_MESH_MAGICK")
         layout.prop(self, "TUNDRA_ROOT")
         layout.prop(self, "MESH_PREVIEWER")

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -64,7 +64,7 @@ _CONFIG_DEFAULTS_ALL = {
     'GENERATE_EDGE_LISTS' : False,
     'GENERATE_TANGENTS' : "0",
     'OPTIMISE_ANIMATIONS' : True,
-    'interface_toggle': False,
+    'INTERFACE_TOGGLE': False,
     'OPTIMISE_VERTEX_BUFFERS' : True,
     'OPTIMISE_VERTEX_BUFFERS_OPTIONS' : 'puqs',
     
@@ -72,6 +72,7 @@ _CONFIG_DEFAULTS_ALL = {
     'LOD_LEVELS' : 0,
     'LOD_DISTANCE' : 300,
     'LOD_PERCENT' : 40,
+    'LOD_MESH_TOOLS' : False,
     
     # Pose Animation
     'SHAPE_ANIMATIONS' : True,
@@ -85,14 +86,15 @@ _CONFIG_DEFAULTS_ALL = {
     'TUNDRA_STREAMING' : True
 }
 
-_CONFIG_TAGS_ = 'OGRETOOLS_XML_CONVERTER OGRETOOLS_MESH_MAGICK TUNDRA_ROOT MESH_PREVIEWER IMAGE_MAGICK_CONVERT USER_MATERIALS SHADER_PROGRAMS TUNDRA_STREAMING'.split()
+_CONFIG_TAGS_ = 'OGRETOOLS_XML_CONVERTER OGRETOOLS_MESH_UPGRADER OGRETOOLS_MESH_MAGICK TUNDRA_ROOT MESH_PREVIEWER IMAGE_MAGICK_CONVERT USER_MATERIALS SHADER_PROGRAMS TUNDRA_STREAMING'.split()
 
 ''' todo: Change pretty much all of these windows ones. Make a smarter way of detecting
     Ogre tools and Tundra from various default folders. Also consider making a installer that
     ships Ogre cmd line tools to ease the setup steps for end users. '''
 
 _CONFIG_DEFAULTS_WINDOWS = {
-    'OGRETOOLS_XML_CONVERTER' : 'C:\\OgreCommandLineTools\\OgreXmlConverter.exe',
+    'OGRETOOLS_XML_CONVERTER' : 'C:\\OgreCommandLineTools\\OgreXMLConverter.exe',
+    'OGRETOOLS_MESH_UPGRADER' : 'C:\\OgreCommandLineTools\\OgreMeshUpgrader.exe',
     'OGRETOOLS_MESH_MAGICK' : 'C:\\OgreCommandLineTools\\MeshMagick.exe',
     'TUNDRA_ROOT' : 'C:\\Tundra2',
     'MESH_PREVIEWER' : 'C:\\OgreMeshy\\Ogre Meshy.exe',
@@ -106,6 +108,7 @@ _CONFIG_DEFAULTS_UNIX = {
     # just trust the env PATH variable
     'IMAGE_MAGICK_CONVERT' : 'convert',
     'OGRETOOLS_XML_CONVERTER' : 'OgreXMLConverter',
+    'OGRETOOLS_MESH_UPGRADER' : 'OgreMeshUpgrader',
     'OGRETOOLS_MESH_MAGICK' : '/usr/local/bin/MeshMagick',
     'TUNDRA_ROOT' : '~/Tundra2',
     'MESH_PREVIEWER' : 'ogre-meshviewer',
@@ -160,10 +163,16 @@ def load_config():
             registry_key = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r'Software\blender2ogre', 0, winreg.KEY_READ)
             exe_install_dir = winreg.QueryValueEx(registry_key, "Path")[0]
             if exe_install_dir != "":
-                # OgreXmlConverter
+                # OgreXMLConverter
+                if os.path.isfile(exe_install_dir + "OgreXMLConverter.exe"):
+                    logger.info ("Using OgreXMLConverter from install path: %sOgreXMLConverter.exe" % exe_install_dir)
+                    config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXMLConverter.exe"
+
+                # OgreMeshUpgrader
                 if os.path.isfile(exe_install_dir + "OgreXmlConverter.exe"):
-                    logger.info ("Using OgreXmlConverter from install path: %sOgreXmlConverter.exe" % exe_install_dir)
-                    config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXmlConverter.exe"
+                    logger.info ("Using OgreMeshUpgrader from install path: %sOgreMeshUpgrader.exe" % exe_install_dir)
+                    config_dict['OGRETOOLS_MESH_UPGRADER'] = exe_install_dir + "OgreMeshUpgrader.exe"
+
                 # Run auto updater as silent. Notifies user if there is a new version out.
                 # This will not show any UI if there are no update and will go to network
                 # only once per 2 days so it wont be spending much resources either.

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -371,7 +371,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         logger.info('- Done at %s seconds' % timer_diff_str(start))
 
         # Generate lod levels
-        if isLOD == False and ob.type == 'MESH' and config.get('LOD_LEVELS') > 0:
+        if isLOD == False and ob.type == 'MESH' and config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == False:
             lod_levels = config.get('LOD_LEVELS')
             lod_distance = config.get('LOD_DISTANCE')
             lod_ratio = config.get('LOD_PERCENT') / 100.0
@@ -679,8 +679,15 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
     # Start .mesh.xml to .mesh convertion tool
     util.xml_convert(target_file, has_uvs=dotextures)
 
-    # note that exporting the skeleton does not happen here anymore
-    # it moved to the function dot_skeleton in its own module
+    logger.info('- Created %s.mesh in total time %s seconds' % (obj_name, timer_diff_str(start)))
+
+    # If requested by the user, generate LOD levels through OgreMeshUpgrader
+    if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+        target_mesh_file = os.path.join(path, '%s.mesh' % obj_name )
+        util.lod_create(target_mesh_file)
+    
+    # Note that exporting the skeleton does not happen here anymore
+    # It was moved to the function dot_skeleton in its own module (skeleton.py)
 
     mats = []
     for mat_name, extern, mat in materials:
@@ -689,8 +696,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             mats.append(mat_name)
         else:
             logger.info("Extern material: %s" % mat_name)
-
-    logger.info('- Created %s.mesh in total time %s seconds' % (obj_name, timer_diff_str(start)))
 
     return mats
 

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -35,7 +35,7 @@ def auto_register(register):
     yield from export.auto_register(register)
     yield from helper.auto_register(register)
 
-    if register and config.get('interface_toggle'):
+    if register and config.get('INTERFACE_TOGGLE'):
         OP_interface_toggle.toggle(True)
 
 """
@@ -54,11 +54,11 @@ class OP_interface_toggle(bpy.types.Operator):
         return True
 
     def invoke(self, context, event):
-        show = config.get('interface_toggle')
+        show = config.get('INTERFACE_TOGGLE')
         print("toggle invoked:", show)
         print(dir(event))
         self.toggle(not show)
-        config.update(interface_toggle=not show)
+        config.update(INTERFACE_TOGGLE=not show)
         return {'FINISHED'}
 
     @classmethod
@@ -77,7 +77,7 @@ class HT_toggle_ogre(bpy.types.Header):
 
     def draw(self, context):
         layout = self.layout
-        show = config.get('interface_toggle')
+        show = config.get('INTERFACE_TOGGLE')
         icon = 'CHECKBOX_DEHLT'
         if show:
             icon = 'CHECKBOX_HLT'

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -21,13 +21,13 @@ if "bpy" in locals():
 # are already in locals() and those statements do not do anything.
 from bpy.props import EnumProperty, BoolProperty, FloatProperty, StringProperty, IntProperty
 from .. import config
+from ..ogre import material
+from ..ogre import mesh
+from ..ogre import scene
+from ..ogre import skeleton
 from ..report import Report
 from ..util import *
 from ..xml import *
-from ..ogre import mesh
-from ..ogre import skeleton
-from ..ogre import scene
-from ..ogre import material
 
 logger = logging.getLogger('export')
 
@@ -96,7 +96,7 @@ class _OgreCommonExport_(object):
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"], 
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"], 
             "Mesh" : ["EX_MESH", "EX_MESH_OVERWRITE", "EX_V1_EXTREMITY_POINTS", "EX_Vx_GENERATE_EDGE_LISTS", "EX_GENERATE_TANGENTS", "EX_Vx_OPTIMISE_ANIMATIONS", "EX_V2_OPTIMISE_VERTEX_BUFFERS", "OPTIMISE_VERTEX_BUFFERS_OPTIONS"], 
-            "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT"], 
+            "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT", "EX_LOD_MESH_TOOLS"], 
             "Shape Animation" : ["EX_SHAPE_ANIMATIONS", "EX_SHAPE_NORMALS"], 
             "Logging" : ["EX_Vx_EXPORT_ENABLE_LOGGING"]
         }
@@ -373,6 +373,12 @@ S - strips the buffers for shadow mapping (consumes less space and memory)""",
         description="LOD percentage reduction",
         min=0, max=99,
         default=config.get('LOD_PERCENT'))
+    EX_LOD_MESH_TOOLS = BoolProperty(
+        name="Use OgreMesh Tools",
+        description="""Use OgreMeshUpgrader/OgreMeshTool instead of Blender to generate the mesh LODs.
+OgreMeshUpgrader/OgreMeshTool does LOD by removing edges, which allows only changing the index buffer and re-use the vertex-buffer (storage efficient).
+Blenders decimate does LOD by collapsing vertices, which can result in a visually better LOD, but needs different vertex-buffers per LOD.""",
+        default=config.get('LOD_MESH_TOOLS'))
 
     # Pose Animation
     EX_SHAPE_ANIMATIONS = BoolProperty(


### PR DESCRIPTION
Give users the option to use `OgreMeshUpgrader` to generate LODs instead of the bpy method
 - One advantage is that the LODs are stored in the same mesh, no `Model_LODx.mesh` additional files.
 - The algorithm used by `OgreMeshUpgrader` might be better than using Blenders Decimate modifier
 - It is faster
