### PR TITLE
LOD: Give the option to use Ogre Tools to generate LODs, and more...

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -68,6 +68,12 @@ class Blender2OgreAddonPreferences(bpy.types.AddonPreferences):
         default=config.CONFIG['OGRETOOLS_XML_CONVERTER'],
         update=apply_preferences_to_config
     )
+    OGRETOOLS_MESH_UPGRADER : bpy.props.StringProperty(
+        name="OGRETOOLS_MESH_UPGRADER",
+        subtype='FILE_PATH',
+        default=config.CONFIG['OGRETOOLS_MESH_UPGRADER'],
+        update=apply_preferences_to_config
+    )
     OGRETOOLS_MESH_MAGICK : bpy.props.StringProperty(
         name="OGRETOOLS_MESH_MAGICK",
         subtype='FILE_PATH',
@@ -102,6 +108,7 @@ class Blender2OgreAddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "OGRETOOLS_XML_CONVERTER")
+        layout.prop(self, "OGRETOOLS_MESH_UPGRADER")
         layout.prop(self, "OGRETOOLS_MESH_MAGICK")
         layout.prop(self, "TUNDRA_ROOT")
         layout.prop(self, "MESH_PREVIEWER")

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -64,7 +64,7 @@ _CONFIG_DEFAULTS_ALL = {
     'GENERATE_EDGE_LISTS' : False,
     'GENERATE_TANGENTS' : "0",
     'OPTIMISE_ANIMATIONS' : True,
-    'interface_toggle': False,
+    'INTERFACE_TOGGLE': False,
     'OPTIMISE_VERTEX_BUFFERS' : True,
     'OPTIMISE_VERTEX_BUFFERS_OPTIONS' : 'puqs',
     
@@ -72,6 +72,7 @@ _CONFIG_DEFAULTS_ALL = {
     'LOD_LEVELS' : 0,
     'LOD_DISTANCE' : 300,
     'LOD_PERCENT' : 40,
+    'LOD_MESH_TOOLS' : False,
     
     # Pose Animation
     'SHAPE_ANIMATIONS' : True,
@@ -85,14 +86,15 @@ _CONFIG_DEFAULTS_ALL = {
     'TUNDRA_STREAMING' : True
 }
 
-_CONFIG_TAGS_ = 'OGRETOOLS_XML_CONVERTER OGRETOOLS_MESH_MAGICK TUNDRA_ROOT MESH_PREVIEWER IMAGE_MAGICK_CONVERT USER_MATERIALS SHADER_PROGRAMS TUNDRA_STREAMING'.split()
+_CONFIG_TAGS_ = 'OGRETOOLS_XML_CONVERTER OGRETOOLS_MESH_UPGRADER OGRETOOLS_MESH_MAGICK TUNDRA_ROOT MESH_PREVIEWER IMAGE_MAGICK_CONVERT USER_MATERIALS SHADER_PROGRAMS TUNDRA_STREAMING'.split()
 
 ''' todo: Change pretty much all of these windows ones. Make a smarter way of detecting
     Ogre tools and Tundra from various default folders. Also consider making a installer that
     ships Ogre cmd line tools to ease the setup steps for end users. '''
 
 _CONFIG_DEFAULTS_WINDOWS = {
-    'OGRETOOLS_XML_CONVERTER' : 'C:\\OgreCommandLineTools\\OgreXmlConverter.exe',
+    'OGRETOOLS_XML_CONVERTER' : 'C:\\OgreCommandLineTools\\OgreXMLConverter.exe',
+    'OGRETOOLS_MESH_UPGRADER' : 'C:\\OgreCommandLineTools\\OgreMeshUpgrader.exe',
     'OGRETOOLS_MESH_MAGICK' : 'C:\\OgreCommandLineTools\\MeshMagick.exe',
     'TUNDRA_ROOT' : 'C:\\Tundra2',
     'MESH_PREVIEWER' : 'C:\\OgreMeshy\\Ogre Meshy.exe',
@@ -106,6 +108,7 @@ _CONFIG_DEFAULTS_UNIX = {
     # just trust the env PATH variable
     'IMAGE_MAGICK_CONVERT' : 'convert',
     'OGRETOOLS_XML_CONVERTER' : 'OgreXMLConverter',
+    'OGRETOOLS_MESH_UPGRADER' : 'OgreMeshUpgrader',
     'OGRETOOLS_MESH_MAGICK' : '/usr/local/bin/MeshMagick',
     'TUNDRA_ROOT' : '~/Tundra2',
     'MESH_PREVIEWER' : 'ogre-meshviewer',
@@ -160,10 +163,16 @@ def load_config():
             registry_key = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r'Software\blender2ogre', 0, winreg.KEY_READ)
             exe_install_dir = winreg.QueryValueEx(registry_key, "Path")[0]
             if exe_install_dir != "":
-                # OgreXmlConverter
+                # OgreXMLConverter
+                if os.path.isfile(exe_install_dir + "OgreXMLConverter.exe"):
+                    logger.info ("Using OgreXMLConverter from install path: %sOgreXMLConverter.exe" % exe_install_dir)
+                    config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXMLConverter.exe"
+
+                # OgreMeshUpgrader
                 if os.path.isfile(exe_install_dir + "OgreXmlConverter.exe"):
-                    logger.info ("Using OgreXmlConverter from install path: %sOgreXmlConverter.exe" % exe_install_dir)
-                    config_dict['OGRETOOLS_XML_CONVERTER'] = exe_install_dir + "OgreXmlConverter.exe"
+                    logger.info ("Using OgreMeshUpgrader from install path: %sOgreMeshUpgrader.exe" % exe_install_dir)
+                    config_dict['OGRETOOLS_MESH_UPGRADER'] = exe_install_dir + "OgreMeshUpgrader.exe"
+
                 # Run auto updater as silent. Notifies user if there is a new version out.
                 # This will not show any UI if there are no update and will go to network
                 # only once per 2 days so it wont be spending much resources either.

--- a/io_ogre/meshy.py
+++ b/io_ogre/meshy.py
@@ -95,7 +95,7 @@ class OGREMESH_OT_preview(bpy.types.Operator):
             else:
                 subprocess.Popen([CONFIG['MESH_PREVIEWER'], 'C:\\tmp\\preview.mesh'] )
         except:
-            Report.messages.append('ERROR: Viewer not found at "%s"' % CONFIG['MESH_PREVIEWER'])
+            Report.errors.append('Viewer not found at "%s"' % CONFIG['MESH_PREVIEWER'])
 
         Report.show()
         return {'FINISHED'}

--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -1,20 +1,35 @@
-from datetime import datetime
-from os.path import join
-import math
-import shutil
-import tempfile
 
-from bpy_extras import io_utils
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "util" in locals():
+        importlib.reload(util)
+    if "shader" in locals():
+        importlib.reload(shader)
+    if "report" in locals():
+        importlib.reload(report)
+    if "program" in locals():
+        importlib.reload(program)
 
-from bpy.props import EnumProperty
-from bpy_extras import node_shader_utils
-from mathutils import Vector
-
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
+import logging, os, shutil, tempfile, math
+from .. import config
 from .. import shader
 from .. import util
 from ..report import Report
 from ..util import *
 from .program import OgreProgram
+from bpy.props import EnumProperty
+from bpy_extras import io_utils
+from bpy_extras import node_shader_utils
+from datetime import datetime
+from itertools import chain
+from mathutils import Vector
+from os.path import join, split, splitext
 
 logger = logging.getLogger('material')
 

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -181,7 +181,12 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         if tangents:
             mesh.calc_tangents(uvmap=mesh.uv_layers.active.name)
 
+        progressScale = 1.0 / (len(mesh.polygons) - 1)
         for F in mesh.polygons:
+            percent = F.index * progressScale
+            sys.stdout.write( "\r + Faces [" + '=' * int(percent * 50) + '>' + '.' * int(50 - percent * 50) + "] " + str(int(percent * 10000) / 100.0) + "%   ")
+            sys.stdout.flush()
+            
             smooth = F.use_smooth
             tri = (F.vertices[0], F.vertices[1], F.vertices[2])
             face = []
@@ -298,6 +303,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         doc.end_tag('vertexbuffer')
         doc.end_tag('sharedgeometry')
 
+        print("")
         logger.info('- Done at %s seconds' % timer_diff_str(start))
         logger.info('* Writing submeshes')
 
@@ -376,7 +382,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         logger.info('- Done at %s seconds' % timer_diff_str(start))
 
         # Generate lod levels
-        if isLOD == False and ob.type == 'MESH' and config.get('LOD_LEVELS') > 0:
+        if isLOD == False and ob.type == 'MESH' and config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == False:
             lod_levels = config.get('LOD_LEVELS')
             lod_distance = config.get('LOD_DISTANCE')
             lod_ratio = config.get('LOD_PERCENT') / 100.0
@@ -686,8 +692,15 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
     # Start .mesh.xml to .mesh convertion tool
     util.xml_convert(target_file, has_uvs=dotextures)
 
-    # note that exporting the skeleton does not happen here anymore
-    # it moved to the function dot_skeleton in its own module
+    logger.info('- Created %s.mesh in total time %s seconds' % (obj_name, timer_diff_str(start)))
+
+    # If requested by the user, generate LOD levels through OgreMeshUpgrader
+    if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+        target_mesh_file = os.path.join(path, '%s.mesh' % obj_name )
+        util.lod_create(target_mesh_file)
+    
+    # Note that exporting the skeleton does not happen here anymore
+    # It was moved to the function dot_skeleton in its own module (skeleton.py)
 
     mats = []
     for mat_name, extern, mat in materials:
@@ -696,8 +709,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             mats.append(mat_name)
         else:
             logger.info("Extern material: %s" % mat_name)
-
-    logger.info('- Created %s.mesh in total time %s seconds' % (obj_name, timer_diff_str(start)))
 
     return mats
 

--- a/io_ogre/ogre/program.py
+++ b/io_ogre/ogre/program.py
@@ -1,3 +1,13 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 import os, logging
 from .. import config
 

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -1,16 +1,38 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "material" in locals():
+        importlib.reload(material)
+    if "mesh" in locals():
+        importlib.reload(mesh)
+    if "skeleton" in locals():
+        importlib.reload(skeleton)
+    if "config" in locals():
+        importlib.reload(config)
+    if "util" in locals():
+        importlib.reload(util)
+    if "report" in locals():
+        importlib.reload(report)
+    if "xml" in locals():
+        importlib.reload(xml)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
 import bpy, mathutils, os, getpass, math
 from os.path import join
-from .. import util
-from .. import config
+from . import material
 from . import mesh
 from . import skeleton
+from .. import bl_info
+from .. import config
+from .. import util
 from ..report import Report
 from ..util import *
 from ..xml import *
-from .mesh import *
 from .material import *
-from . import material
-from .. import bl_info
+from .mesh import *
 
 logger = logging.getLogger('scene')
 
@@ -173,7 +195,6 @@ def dot_scene(path, scene_name=None):
         #bpy.context.scene.objects.unlink( ob )
         #bpy.context.collection.objects.unlink( ob )
         bpy.data.objects.remove(ob)
-
 
 class _WrapLogic(object):
     SwapName = { 'frame_property' : 'animation' } # custom name hacks
@@ -449,8 +470,8 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                         break
                 if collisionFile:
                     mesh_collision_files[ ob.data.name ] = collisionFile
-                    mesh.dot_mesh(child, target_path, force_name='%s_collision_%s' % (prefix, ob.data.name) )
-                    skeleton.dot_skeleton(child, target_path)
+                    mesh.dot_mesh(child, path, force_name='%s_collision_%s' % (prefix, ob.data.name) )
+                    skeleton.dot_skeleton(child, path)
 
         if collisionPrim:
             e.setAttribute('collisionPrim', collisionPrim )

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -1,4 +1,20 @@
-import bpy, mathutils, logging
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "report" in locals():
+        importlib.reload(report)
+    if "xml" in locals():
+        importlib.reload(xml)
+    if "util" in locals():
+        importlib.reload(util)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
+import bpy, mathutils, logging, time
 from .. import config
 from ..report import Report
 from ..xml import RDocument
@@ -27,11 +43,19 @@ def dot_skeleton(obj, path, **kwargs):
         name = kwargs.get('force_name') or obj.data.name
         name = util.clean_object_name(name)
         xmlfile = join(path, '%s.skeleton.xml' % name)
+        
+        logger.info('* Generating: %s.skeleton.xml' % name)
+
+        start = time.time()
+       
         with open(xmlfile, 'wb') as fd:
             fd.write( bytes(skel.to_xml(),'utf-8') )
 
         if kwargs.get('invoke_xml_converter', True):
             util.xml_convert( xmlfile )
+            
+        logger.info('- Done at %s seconds' % util.timer_diff_str(start))
+            
         return name + '.skeleton'
 
     return None
@@ -298,9 +322,9 @@ class Skeleton(object):
 
     def __init__(self, ob ):
         if ob.location.x != 0 or ob.location.y != 0 or ob.location.z != 0:
-            Report.warnings.append('ERROR: Mesh (%s): is offset from Armature - zero transform is required' % ob.name)
+            Report.warnings.append('Mesh (%s): is offset from Armature - zero transform is required' % ob.name)
         if ob.scale.x != 1 or ob.scale.y != 1 or ob.scale.z != 1:
-            Report.warnings.append('ERROR: Mesh (%s): has been scaled - scale(1,1,1) is required' % ob.name)
+            Report.warnings.append('Mesh (%s): has been scaled - scale(1,1,1) is required' % ob.name)
 
         self.object = ob
         self.bones = []
@@ -323,7 +347,7 @@ class Skeleton(object):
         #self.object_space_transformation = e.to_matrix().to_4x4()
         x,y,z = arm.matrix_local.to_euler()
         if x != 0 or y != 0 or z != 0:
-            Report.warnings.append('ERROR: Armature: %s is rotated - (rotation is ignored)' % arm.name)
+            Report.warnings.append('Armature: %s is rotated - (rotation is ignored)' % arm.name)
 
         ## setup bones for Ogre format ##
         for b in self.bones:
@@ -336,9 +360,9 @@ class Skeleton(object):
                 b.compute_rest()
                 loc,rot,scl = b.ogre_rest_matrix.decompose()
                 #if loc.x or loc.y or loc.z:
-                #    Report.warnings.append('ERROR: root bone has non-zero transform (location offset)')
+                #    Report.errors.append('Root bone has non-zero transform (location offset)')
                 #if rot.w > ep or rot.x > ep or rot.y > ep or rot.z < 1.0-ep:
-                #    Report.warnings.append('ERROR: root bone has non-zero transform (rotation offset)')
+                #    Report.errors.append('Root bone has non-zero transform (rotation offset)')
                 self.roots.append( b )
 
     def write_animation( self, arm, actionName, frameBegin, frameEnd, doc, parentElement ):

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -43,8 +43,8 @@ def auto_register(register):
     yield from export.auto_register(register)
     yield from helper.auto_register(register)
 
-    if register and config.get('interface_toggle'):
-        OGRE_OP_interface_toggle.toggle(True)
+    if register and config.get('INTERFACE_TOGGLE'):
+        OP_interface_toggle.toggle(True)
 
 """
 General purpose ui elements
@@ -62,11 +62,11 @@ class OGRE_OP_interface_toggle(bpy.types.Operator):
         return True
 
     def invoke(self, context, event):
-        show = config.get('interface_toggle')
+        show = config.get('INTERFACE_TOGGLE')
         print("toggle invoked:", show)
         print(dir(event))
         self.toggle(not show)
-        config.update(interface_toggle=not show)
+        config.update(INTERFACE_TOGGLE=not show)
         return {'FINISHED'}
 
     @classmethod
@@ -85,7 +85,7 @@ class OGRE_HT_toggle_ogre(bpy.types.Header):
 
     def draw(self, context):
         layout = self.layout
-        show = config.get('interface_toggle')
+        show = config.get('INTERFACE_TOGGLE')
         icon = 'CHECKBOX_DEHLT'
         if show:
             icon = 'CHECKBOX_HLT'

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -21,13 +21,13 @@ if "bpy" in locals():
 # are already in locals() and those statements do not do anything.
 from bpy.props import EnumProperty, BoolProperty, FloatProperty, StringProperty, IntProperty
 from .. import config
+from ..ogre import material
+from ..ogre import mesh
+from ..ogre import scene
+from ..ogre import skeleton
 from ..report import Report
 from ..util import *
 from ..xml import *
-from ..ogre import mesh
-from ..ogre import skeleton
-from ..ogre import scene
-from ..ogre import material
 
 logger = logging.getLogger('export')
 
@@ -66,7 +66,7 @@ class _OgreCommonExport_(object):
 
         wm = context.window_manager
         fs = wm.fileselect_add(self)
-
+        
         return {'RUNNING_MODAL'}
 
     def draw(self, context):
@@ -91,12 +91,12 @@ class _OgreCommonExport_(object):
         # Options associated with each section
         section_options = {
             "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_EXPORT_VERSION"], 
-            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS"], 
+            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS"], 
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS"], 
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"], 
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"], 
             "Mesh" : ["EX_MESH", "EX_MESH_OVERWRITE", "EX_V1_EXTREMITY_POINTS", "EX_Vx_GENERATE_EDGE_LISTS", "EX_GENERATE_TANGENTS", "EX_Vx_OPTIMISE_ANIMATIONS", "EX_V2_OPTIMISE_VERTEX_BUFFERS", "OPTIMISE_VERTEX_BUFFERS_OPTIONS"], 
-            "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT"], 
+            "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT", "EX_LOD_MESH_TOOLS"], 
             "Shape Animation" : ["EX_SHAPE_ANIMATIONS", "EX_SHAPE_NORMALS"], 
             "Logging" : ["EX_Vx_EXPORT_ENABLE_LOGGING"]
         }
@@ -377,6 +377,12 @@ S - strips the buffers for shadow mapping (consumes less space and memory)""",
         description="LOD percentage reduction",
         min=0, max=99,
         default=config.get('LOD_PERCENT')) = {}
+    EX_LOD_MESH_TOOLS : BoolProperty(
+        name="Use OgreMesh Tools",
+        description="""Use OgreMeshUpgrader/OgreMeshTool instead of Blender to generate the mesh LODs.
+OgreMeshUpgrader/OgreMeshTool does LOD by removing edges, which allows only changing the index buffer and re-use the vertex-buffer (storage efficient).
+Blenders decimate does LOD by collapsing vertices, which can result in a visually better LOD, but needs different vertex-buffers per LOD.""",
+        default=config.get('LOD_MESH_TOOLS')) = {}
 
     # Pose Animation
     EX_SHAPE_ANIMATIONS : BoolProperty(


### PR DESCRIPTION
 - Give users the option to use OgreMeshUpgrader/OgreMeshTool to generate LODs instead of the bpy method
 - Replace asserts with error reports when OgreXMLConverter/OgreMeshTool return with non-zero status
 - Copy kenshi exporter progress bar
 - More module reloading
 - Small fixes

(Basically, same thing as 2.7x-support branch)
