### PR TITLE
Initial support for node animation

### DIFF
--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -38,6 +38,8 @@ _CONFIG_DEFAULTS_ALL = {
     'EXPORT_USER' : True,
     'FORCE_CAMERA' : True,
     'FORCE_LAMPS' : True,
+    'NODE_ANIMATION' : True,
+    #'NODE_KEYFRAMES' : False,
     
     # Materials
     'MATERIALS' : True,

--- a/io_ogre/ogre/node_anim.py
+++ b/io_ogre/ogre/node_anim.py
@@ -1,0 +1,178 @@
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "report" in locals():
+        importlib.reload(report)
+    if "xml" in locals():
+        importlib.reload(xml)
+    if "util" in locals():
+        importlib.reload(util)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
+import bpy, mathutils, logging, time
+from .. import config
+from ..report import Report
+from ..xml import RDocument
+from .. import util
+from os.path import join
+
+logger = logging.getLogger('node_anim')
+
+# Node Animation, based on the work done in Easy Ogre Exporter (3D Studio Max exporter)
+# https://github.com/OGRECave/EasyOgreExporter/blob/master/source/ExScene.cpp#L104
+# The idea is that the data exported by blender2ogre would have the same format as the one exported by Easy Ogre Exporter which would be the standard by being the first ones to implement it
+# There seems to be some support for animation in the Maya Ogre Exporter, but for the camera so it is possible to animate values like FOV
+# https://github.com/bitgate/maya-ogre3d-exporter/blob/master/src/ogreExporter.cpp#L373
+
+def dot_nodeanim(ob, doc, xmlnode):
+    """
+    Create the node animation for this object. 
+    This is only possible if the object has any animation data
+
+    ob: the blender object
+    doc: the parent xml node to attach the animation data
+    """
+
+    anim = ob.animation_data
+    
+    if anim is None or anim.nla_tracks is None:
+        return
+
+    savedUseNla = anim.use_nla
+    savedAction = anim.action
+    anim.use_nla = False
+    if not len( anim.nla_tracks ):
+        Report.warnings.append('You must assign an NLA strip to object (%s) that defines the start and end frames' % ob.name)
+
+    logger.info('* Generating node animation for: %s' % ob.name)
+
+    start = time.time()
+
+    actions = {}  # actions by name
+    # the only thing NLA is used for is to gather the names of the actions
+    # it doesn't matter if the actions are all in the same NLA track or in different tracks
+    for nla in anim.nla_tracks:        # NLA required, lone actions not supported
+        logger.info('+ NLA track: %s' % nla.name)
+
+        for strip in nla.strips:
+            action = strip.action
+            actions[ action.name ] = [action, strip.action_frame_start, strip.action_frame_end]
+            logger.info('  - Action name: %s' % action.name)
+            logger.info('  -  Strip name: %s' % strip.name)
+
+    actionNames = sorted( actions.keys() )  # output actions in alphabetical order
+    for actionName in actionNames:
+        actionData = actions[ actionName ]
+        action = actionData[0]
+        anim.action = action  # set as the current action
+        write_animation( ob, action, actionData[1], actionData[2], doc, xmlnode )
+
+    # restore these to what they originally were
+    anim.action = savedAction
+    anim.use_nla = savedUseNla
+
+    logger.info('- Done at %s seconds' % util.timer_diff_str(start))
+
+# A note about the option: NODE_KEYFRAMES
+# If NODE_KEYFRAMES is False, then this function processess the objects animation frame by frame, instead of using its keyframes
+# The advantage of this method is that it respects the users tuning of the node animation curves
+# The disadvantage is that it generates more data than just processing the keyframes and it might clutter the .scene file.
+# Since the .scene file is not a binary file it might take longer to process with this method
+
+# If NODE_KEYFRAMES is True, then this function processess the objects keyframes one by one by going through the F-Curves
+# The advantage of this method is that it is very fast and produces less data (only the keyframes)
+# The disadvantage is that if the user did an extensive tuning of the node animation curves that tuning is lost since only IM_LINEAR / IM_SPLINE at the global level is supported by Ogre
+# Another disadvantage is that it is very difficult if not impossible to choose between IM_LINEAR or IM_SPLINE for the resulting animation since the user might be choosing between different interpolation types for each F-Curve
+def write_animation(ob, action, frame_start, frame_end, doc, xmlnode):
+
+    _fps = float( bpy.context.scene.render.fps )
+
+    # Actually in Blender this does not make sense because there is only one possible animation per object, but lets maintain compatibility with Easy Ogre Exporter
+    aa = doc.createElement('animations')
+    xmlnode.appendChild(aa)
+    
+    a = doc.createElement('animation')
+    a.setAttribute("name", "%s" % action.name)
+    a.setAttribute("enable", "false")
+    a.setAttribute("loop", "false")
+    a.setAttribute("interpolationMode", "linear")
+    a.setAttribute("rotationInterpolationMode", "linear")
+    a.setAttribute("length", '%6f' % ((frame_end) / _fps))
+    aa.appendChild(a)
+    
+    frame_current = bpy.context.scene.frame_current
+    
+    initial_location = mathutils.Vector((0, 0, 0))
+    initial_rotation = mathutils.Quaternion((1, 0, 0, 0))
+    
+    frames = range(int(frame_start), int(frame_end) + 1)
+    
+    # If NODE_KEYFRAMES is True, then use only the keyframes to export the animation
+    #if config.get('NODE_KEYFRAMES'):
+    #    frames = get_keyframes(action)
+    
+    for frame in frames:
+
+        kf = doc.createElement('keyframe')
+        kf.setAttribute("time", '%6f' % (frame / _fps))
+        a.appendChild(kf)
+
+        bpy.context.scene.frame_set(frame)
+        
+        translation = mathutils.Vector((0, 0, 0))
+        rotation_quat = mathutils.Quaternion((1, 0, 0, 0))
+
+        if frame == frame_start:
+            initial_location = util.swap( ob.matrix_local.to_translation() )
+            initial_rotation = util.swap( ob.matrix_local.to_quaternion() )
+        else:
+            translation = util.swap( ob.matrix_local.to_translation() ) - initial_location
+            rotation_quat = initial_rotation.rotation_difference( util.swap( ob.matrix_local.to_quaternion() ) )
+        
+        t = doc.createElement('position')
+        t.setAttribute("x", '%6f' % translation.x)
+        t.setAttribute("y", '%6f' % translation.y)
+        t.setAttribute("z", '%6f' % translation.z)
+        kf.appendChild(t)
+        
+        q = doc.createElement('rotation')
+        q.setAttribute("qw", '%6f' % rotation_quat.w)
+        q.setAttribute("qx", '%6f' % rotation_quat.x)
+        q.setAttribute("qy", '%6f' % rotation_quat.y)
+        q.setAttribute("qz", '%6f' % rotation_quat.z)
+        kf.appendChild(q)
+        
+        s = doc.createElement('scale')
+        # Scale is different in Ogre from blender - rotation is removed
+        ri = ob.matrix_local.to_quaternion().inverted().to_matrix()
+        scale = ri.to_4x4() * ob.matrix_local
+        v = util.swap( scale.to_scale() )
+        x=abs(v.x); y=abs(v.y); z=abs(v.z)
+        s.setAttribute("x", '%6f' % x)
+        s.setAttribute("y", '%6f' % y)
+        s.setAttribute("z", '%6f' % z)
+        kf.appendChild(s)
+        
+    bpy.context.scene.frame_set(frame_current)
+
+def get_keyframes(action):
+
+    keyframes = {}
+    
+    for fcurve in action.fcurves:
+
+        for keyframe in fcurve.keyframe_points:
+            
+            frame, value = keyframe.co
+            
+            # Add Keyframe if it does not exist
+            if frame not in keyframes:
+                keyframes[frame] = frame
+
+    return sorted(keyframes)
+

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -5,6 +5,8 @@ if "bpy" in locals():
     import importlib
     if "material" in locals():
         importlib.reload(material)
+    if "node_anim" in locals():
+        importlib.reload(node_anim)
     if "mesh" in locals():
         importlib.reload(mesh)
     if "skeleton" in locals():
@@ -23,6 +25,7 @@ if "bpy" in locals():
 import bpy, mathutils, os, getpass, math
 from os.path import join
 from . import material
+from . import node_anim
 from . import mesh
 from . import skeleton
 from .. import bl_info
@@ -53,6 +56,12 @@ def dot_scene(path, scene_name=None):
 
     logger.info("* Processing Scene: %s, path: %s" % (scene_name, path))
     prefix = scene_name
+
+    # If an object has an animation, then we want to export the position at the first frame (with the object at rest)
+    # Otherwise the objects position will be at an arbitrary place if current frame is different from frame_start
+    frame_start = bpy.context.scene.frame_start
+    frame_current = bpy.context.scene.frame_current
+    bpy.context.scene.frame_set(frame_start)
 
     # Nodes (objects) - gather because macros will change selection state
     objects = []
@@ -195,6 +204,9 @@ def dot_scene(path, scene_name=None):
         bpy.data.meshes.remove(ob.data)
         bpy.data.objects.remove(ob)
 
+    # Restore the scene previous frame position
+    bpy.context.scene.frame_set(frame_current)
+
 class _WrapLogic(object):
     SwapName = { 'frame_property' : 'animation' } # custom name hacks
 
@@ -306,47 +318,48 @@ def _mesh_entity_helper(doc, ob, o):
             _property_helper(doc, user, propname, propvalue)
 
 def _ogre_node_helper( doc, ob, prefix='', pos=None, rot=None, scl=None ):
+
+    # Get the object transform matrix
     mat = ob.matrix_local
 
     o = doc.createElement('node')
-    o.setAttribute('name',prefix+ob.name)
-    p = doc.createElement('position')
-    q = doc.createElement('rotation')       #('quaternion')
-    s = doc.createElement('scale')
-    for n in (p,q,s):
-        o.appendChild(n)
+    o.setAttribute('name', prefix + ob.name)
 
     if pos:
         v = swap(pos)
     else:
         v = swap( mat.to_translation() )
-    p.setAttribute('x', '%6f'%v.x)
-    p.setAttribute('y', '%6f'%v.y)
-    p.setAttribute('z', '%6f'%v.z)
+    p = doc.createElement('position')
+    p.setAttribute('x', '%6f' % v.x)
+    p.setAttribute('y', '%6f' % v.y)
+    p.setAttribute('z', '%6f' % v.z)
+    o.appendChild(p)
 
     if rot:
         v = swap(rot)
     else:
         v = swap( mat.to_quaternion() )
-    q.setAttribute('qx', '%6f'%v.x)
-    q.setAttribute('qy', '%6f'%v.y)
-    q.setAttribute('qz', '%6f'%v.z)
-    q.setAttribute('qw','%6f'%v.w)
+    q = doc.createElement('rotation')   #('quaternion')
+    q.setAttribute('qx', '%6f' % v.x)
+    q.setAttribute('qy', '%6f' % v.y)
+    q.setAttribute('qz', '%6f' % v.z)
+    q.setAttribute('qw', '%6f' % v.w)
+    o.appendChild(q)
 
-    if scl:        # this should not be used
+    if scl:     # this should not be used
         v = swap(scl)
         x=abs(v.x); y=abs(v.y); z=abs(v.z)
-        s.setAttribute('x', '%6f'%x)
-        s.setAttribute('y', '%6f'%y)
-        s.setAttribute('z', '%6f'%z)
-    else:        # scale is different in Ogre from blender - rotation is removed
+    else:       # scale is different in Ogre from blender - rotation is removed
         ri = mat.to_quaternion().inverted().to_matrix()
         scale = ri.to_4x4() * mat
         v = swap( scale.to_scale() )
         x=abs(v.x); y=abs(v.y); z=abs(v.z)
-        s.setAttribute('x', '%6f'%x)
-        s.setAttribute('y', '%6f'%y)
-        s.setAttribute('z', '%6f'%z)
+    s = doc.createElement('scale')
+    s.setAttribute('x', '%6f' % x)
+    s.setAttribute('y', '%6f' % y)
+    s.setAttribute('z', '%6f' % z)
+    o.appendChild(s)
+
     return o
 
 def ogre_document(materials):
@@ -389,25 +402,25 @@ def ogre_document(materials):
                ('colourBackground', world.horizon_color)]
         for ctag, color in _c:
             a = doc.createElement(ctag); environ.appendChild( a )
-            a.setAttribute('r', '%s'%color.r)
-            a.setAttribute('g', '%s'%color.g)
-            a.setAttribute('b', '%s'%color.b)
+            a.setAttribute('r', '%3f' % color.r)
+            a.setAttribute('g', '%3f' % color.g)
+            a.setAttribute('b', '%3f' % color.b)
 
     if world and world.mist_settings.use_mist:
         a = doc.createElement('fog'); environ.appendChild( a )
-        a.setAttribute('linearStart', '%s'%world.mist_settings.start )
+        a.setAttribute('linearStart', '%6f' % world.mist_settings.start )
         mist_falloff = world.mist_settings.falloff
         if mist_falloff == 'QUADRATIC': a.setAttribute('mode', 'exp')    # on DTD spec (none | exp | exp2 | linear)
         elif mist_falloff == 'LINEAR': a.setAttribute('mode', 'linear')
         else: a.setAttribute('mode', 'exp2')
         #a.setAttribute('mode', world.mist_settings.falloff.lower() )    # not on DTD spec
-        a.setAttribute('linearEnd', '%s' %(world.mist_settings.start+world.mist_settings.depth))
+        a.setAttribute('linearEnd', '%6f' % (world.mist_settings.start + world.mist_settings.depth))
         a.setAttribute('expDensity', world.mist_settings.intensity)
 
         c = doc.createElement('colourDiffuse'); a.appendChild( c )
-        c.setAttribute('r', '%s'%color.r)
-        c.setAttribute('g', '%s'%color.g)
-        c.setAttribute('b', '%s'%color.b)
+        c.setAttribute('r', '%3f' % color.r)
+        c.setAttribute('g', '%3f' % color.g)
+        c.setAttribute('b', '%3f' % color.b)
 
     return doc
 
@@ -552,7 +565,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             else:
                 logger.warn("<%s> Particle System %s is not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
                 Report.warnings.append("Object \"%s\" has Particle System: \"%s\" not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
-
+        
     elif ob.type == 'CAMERA':
         Report.cameras.append( ob.name )
         c = doc.createElement('camera')
@@ -570,13 +583,13 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             # fov in radians - like OgreMax - requested by cyrfer
             fov = math.radians( fovY*180.0/math.pi )
             c.setAttribute('projectionType', "perspective")
-            c.setAttribute('fov', '%s'%fov)
+            c.setAttribute('fov', '%6f' % fov)
         else: # ob.data.type == "ORTHO":
             c.setAttribute('projectionType', "orthographic")
-            c.setAttribute('orthoScale', '%s'%ob.data.ortho_scale)
+            c.setAttribute('orthoScale', '%6f' % ob.data.ortho_scale)
         a = doc.createElement('clipping'); c.appendChild( a )
-        a.setAttribute('near', '%s' %ob.data.clip_start)    # requested by cyrfer
-        a.setAttribute('far', '%s' %ob.data.clip_end)
+        a.setAttribute('near', '%6f' % ob.data.clip_start)    # requested by cyrfer
+        a.setAttribute('far', '%6f' % ob.data.clip_end)
 
     elif ob.type == 'LAMP' and ob.data.type in 'POINT SPOT SUN'.split():
         Report.lights.append( ob.name )
@@ -595,15 +608,15 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
 
         if ob.data.use_diffuse:
             a = doc.createElement('colourDiffuse'); l.appendChild( a )
-            a.setAttribute('r', '%s'%ob.data.color.r)
-            a.setAttribute('g', '%s'%ob.data.color.g)
-            a.setAttribute('b', '%s'%ob.data.color.b)
+            a.setAttribute('r', '%3f' % ob.data.color.r)
+            a.setAttribute('g', '%3f' % ob.data.color.g)
+            a.setAttribute('b', '%3f' % ob.data.color.b)
 
         if ob.data.use_specular:
             a = doc.createElement('colourSpecular'); l.appendChild( a )
-            a.setAttribute('r', '%s'%ob.data.color.r)
-            a.setAttribute('g', '%s'%ob.data.color.g)
-            a.setAttribute('b', '%s'%ob.data.color.b)
+            a.setAttribute('r', '%3f' % ob.data.color.r)
+            a.setAttribute('g', '%3f' % ob.data.color.g)
+            a.setAttribute('b', '%3f' % ob.data.color.b)
 
         if ob.data.type == 'SPOT':
             a = doc.createElement('lightRange')
@@ -613,11 +626,15 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             a.setAttribute('falloff','1.0')
 
         a = doc.createElement('lightAttenuation'); l.appendChild( a )
-        a.setAttribute('range', '5000' )            # is this an Ogre constant?
-        a.setAttribute('constant', '1.0')        # TODO support quadratic light
-        a.setAttribute('linear', '%s'%(1.0/ob.data.distance))
+        a.setAttribute('range', '5000' )        # is this an Ogre constant?
+        a.setAttribute('constant', '1.0')       # TODO support quadratic light
+        a.setAttribute('linear', '%6f' % (1.0 / ob.data.distance))
         a.setAttribute('quadratic', '0.0')
 
+    # Node Animation
+    if config.get('NODE_ANIMATION'):
+        node_anim.dot_nodeanim(ob, doc, o)
+    
     for child in ob.children:
         dot_scene_node_export( child,
             path, doc = doc, rex = rex,
@@ -629,4 +646,3 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             objects=objects,
             xmlparent=o
         )
-

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -25,8 +25,8 @@ logger = logging.getLogger('skeleton')
 
 def dot_skeleton(obj, path, **kwargs):
     """
-    create the .skeleton file for this object. This is only possible if the object
-    has an armature attached.
+    Create the .skeleton file for this object. 
+    This is only possible if the object has an armature attached.
 
     obj: the blender object
     path: the path where to save this to. Never None and must exist.
@@ -223,7 +223,7 @@ class Keyframe:
         
 # Bone_Track
 # Encapsulates all of the key information for an individual bone within a single animation,
-# and srores that information as XML.
+# and stores that information as XML.
 class Bone_Track:
     def __init__(self, bone):
         self.bone = bone

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -91,7 +91,7 @@ class _OgreCommonExport_(object):
         # Options associated with each section
         section_options = {
             "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_EXPORT_VERSION", "EX_XML_DELETE"], 
-            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS"], 
+            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"],
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS"], 
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"], 
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"], 
@@ -265,6 +265,17 @@ class _OgreCommonExport_(object):
         name="Force Lamps",
         description="Export all Lamps",
         default=config.get('FORCE_LAMPS'))
+    EX_NODE_ANIMATION = BoolProperty(
+        name="Export Node Animations",
+        description="Export Node Animations, these are animations of the objects properties like position, rotation and scale",
+        default=config.get('NODE_ANIMATION'))
+#    EX_NODE_KEYFRAMES = BoolProperty(
+#        name="Only write Node Keyframes",
+#        description="""The default behaviour when exporting Node Animations is to write every keyframe.
+#Select this option if you want to have more control of the Node Animation in your Ogre application
+#Don't select this option if you have any fine tuning of the F-Curves in Blender, since they won't get exported.
+#NOTE: Node Animations based on the 'Follow Path' constraint will most likely fail with this option set to True.""",
+#        default=config.get('NODE_KEYFRAMES'))
     
     # Materials
     EX_MATERIALS = BoolProperty(


### PR DESCRIPTION
2.7x - Initial support for Node Animations
 - Implement Node Animation with option to avoid exporting it (in Scene Options)
 - Set scene frame to first frame to avoid exporting objets in the wrong position (fix for `scene.py`)
 - Apply consistency to the precision of the exported floating values (fix for `scene.py`)
 - Correct color precision
 - Use NLA to determine which actions to export (like `skeleton.py`)

> Apply consistency to the precision of the exported floating values
I checked that this does not generate problems for distant objects (far from (0, 0, 0)).
Placing a cube at position (100000.01, 0, 0), Blender rounds to (100000.0078, 0, 0) and is exported with that value so the limit seems to be Blender in this case.
