### PR TITLE
Node Animation requires initial scale as well

### DIFF
--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -83,7 +83,7 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         for mod in rem: copy.modifiers.remove( mod )
     else:
         copy = ob
-    
+
     # bake mesh
     mesh = copy.to_mesh(bpy.context.scene, True, "PREVIEW")
 

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -565,7 +565,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
             else:
                 logger.warn("<%s> Particle System %s is not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
                 Report.warnings.append("Object \"%s\" has Particle System: \"%s\" not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
-        
+
     elif ob.type == 'CAMERA':
         Report.cameras.append( ob.name )
         c = doc.createElement('camera')

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -361,9 +361,9 @@ class Skeleton(object):
                 b.compute_rest()
                 loc,rot,scl = b.ogre_rest_matrix.decompose()
                 #if loc.x or loc.y or loc.z:
-                #    Report.warnings.append('ERROR: root bone has non-zero transform (location offset)')
+                #    Report.errors.append('Root bone has non-zero transform (location offset)')
                 #if rot.w > ep or rot.x > ep or rot.y > ep or rot.z < 1.0-ep:
-                #    Report.warnings.append('ERROR: root bone has non-zero transform (rotation offset)')
+                #    Report.errors.append('Root bone has non-zero transform (rotation offset)')
                 self.roots.append( b )
 
     def write_animation( self, arm, actionName, frameBegin, frameEnd, doc, parentElement ):

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -91,7 +91,7 @@ class _OgreCommonExport_(object):
         # Options associated with each section
         section_options = {
             "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_EXPORT_VERSION", "EX_XML_DELETE"], 
-            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"],
+            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"], 
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS"], 
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"], 
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"], 


### PR DESCRIPTION
Node Animation requires initial scale as well
 - Stumbled upon a situation where I realized that the scale required the same treatment as the other transforms.
 - Minor fixes to other unrelated parts, not very much really.
 - Don't export/process armature node animations, it can cause problems (they should be parented to an empty as the tutorial says)
