### PR TITLE
Fix for Error when Exporting a Shape Key's Normals (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 	- [External OGRE Materials](#external-ogre-materials)
 	- [Console Export](#console-export)
 	- [Exporting Custom Vertex Groups](#exporting-custom-vertex-groups)
+	- [Exporting Skeletal Animations](#exporting-skeletal-animations)
 	- [Exporting Particle Systems](#exporting-particle-systems)
 	- [Exporting Shape (or Pose) Animations](#exporting-shape-animations)
 	- [Exporting Node Animations](#exporting-node-animations)


### PR DESCRIPTION
 - fixes #56
 - Created a mapping between tesselated faces and polygon faces, before the untesselated mesh was being indexed by tesselated indexes
 - Normals were being stored as a delta from original normal to shape normal, `PlayPenTests.cpp` shows that is not how it should be done.
 - Tested with all Blender basic meshes and different shape keys: Cube / Plane / Triangle / Icosphere / Sphere / Cylinder
 - Tested in Ogre with a geometry shader that shows Normals, that the normals are being correctly deformed by the Shape Keys
 - Tested with MBetters model (still won't work for him due to #78, which is a Ogre 2.x bug)
 - Custom Normals were not being taken into account

 - (Progress Bug) Fix: Avoid division by zero for meshes with only one triangle
 
 - (README) Fix: "Exporting Skeletal Animations" was not in the index

There is still work to do, becase the fix in this case is actually a patch on a bad design.
The proper way to export the Shape Keys would be to apply only the Shape Key to export, create a copy mesh, tesselate it and then export that.
(Crossing fingers that the vertex indexes will be the same as the tesselated mesh without the shape key applied, I don't know if the algorithm is consistent so this approach might fail)

Anyway, the current fix is good enough (for now).
