### PR TITLE
Integrate Kenshi Importer into blender2ogre

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -15,12 +15,12 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 bl_info = {
-    "name": "OGRE Exporter (.scene, .mesh, .skeleton) and RealXtend (.txml)",
-    "author": "Brett, S.Rombauts, F00bar, Waruck, Mind Calamity, Mr.Magne, Jonne Nauha, vax456, Richard Plangger, Pavel Rojtberg",
+    "name": "OGRE Importer-Exporter (.scene, .mesh, .skeleton) and RealXtend (.txml)",
+    "author": "Brett, S.Rombauts, F00bar, Waruck, Mind Calamity, Mr.Magne, Jonne Nauha, vax456, Richard Plangger, Pavel Rojtberg, Guillermo Ojea Quintana",
     "version": (0, 7, 4),
     "blender": (2, 7, 5),
-    "location": "File > Export...",
-    "description": "Export to Ogre xml and binary formats",
+    "location": "File > Import and Export...",
+    "description": "Import and Export to and from Ogre xml and binary formats",
     "wiki_url": "https://github.com/OGRECave/blender2ogre",
     "tracker_url": "https://github.com/OGRECave/blender2ogre/issues",
     "category": "Import-Export"

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -10,7 +10,7 @@ AXIS_MODES =  [
     ('-xzy', '-xzy', 'non standard'),
 ]
 
-MESH_EXPORT_VERSIONS = [
+MESH_TOOL_VERSIONS = [
     ('v1', 'v1', 'Export the mesh as a v1 object'),
     ('v2', 'v2', 'Export the mesh as a v2 object')
 ]
@@ -18,7 +18,7 @@ MESH_EXPORT_VERSIONS = [
 TANGENT_MODES =  [
     ('0', 'none', 'do not export'),
     ('3', 'generate', 'generate'),
-    ('4', 'with parity', 'generate with parity'),
+    ('4', 'with parity', 'generate with parity')
 ]
 
 CONFIG_PATH = bpy.utils.user_resource('CONFIG', path='scripts', create=True)
@@ -28,7 +28,7 @@ CONFIG_FILEPATH = os.path.join(CONFIG_PATH, CONFIG_FILENAME)
 _CONFIG_DEFAULTS_ALL = {
     # General
     'SWAP_AXIS' : 'xyz', # ogre standard is 'xz-y', but swapping is currently broken
-    'MESH_TOOL_EXPORT_VERSION' : 'v2',
+    'MESH_TOOL_VERSION' : 'v2',
     'XML_DELETE' : True,
     
     # Scene
@@ -82,11 +82,20 @@ _CONFIG_DEFAULTS_ALL = {
     'SHAPE_NORMALS' : True,
     
     # Logging
-    'EXPORT_ENABLE_LOGGING' : False,
+    'ENABLE_LOGGING' : False,
     #'DEBUG_LOGGING' : False,
     'SHOW_LOG_NAME' : False,
     
-    'TUNDRA_STREAMING' : True
+    # Tundra
+    'TUNDRA_STREAMING' : True,
+    
+    # Import
+    'IMPORT_NORMALS' : True,
+    'MERGE_SUBMESHES' : True,
+    'IMPORT_ANIMATIONS' : True,
+    'ROUND_FRAMES' : True,
+    'USE_SELECTED_SKELETON' : True,
+    'IMPORT_SHAPEKEYS' : True   
 }
 
 _CONFIG_TAGS_ = 'OGRETOOLS_XML_CONVERTER OGRETOOLS_MESH_UPGRADER OGRETOOLS_MESH_MAGICK TUNDRA_ROOT MESH_PREVIEWER IMAGE_MAGICK_CONVERT USER_MATERIALS SHADER_PROGRAMS TUNDRA_STREAMING'.split()
@@ -210,7 +219,6 @@ def load_config():
 CONFIG = load_config()
 
 def get(name, default=None):
-
     global CONFIG
     if name in CONFIG:
         return CONFIG[name]
@@ -225,7 +233,7 @@ def update(**kwargs):
 
 def save_config():
     global CONFIG
-    #for key in CONFIG: print( '%s =   %s' %(key, CONFIG[key]) )
+    #for key in CONFIG: print( '%s = %s' %(key, CONFIG[key]) )
     if os.path.isdir( CONFIG_PATH ):
         try:
             with open( CONFIG_FILEPATH, 'wb' ) as f:
@@ -236,7 +244,6 @@ def save_config():
         logger.error('Config directory %s does not exist' % CONFIG_PATH)
 
 def update_from_addon_preference(context):
-
     addon_preferences = context.user_preferences.addons["io_ogre"].preferences
 
     for key in _CONFIG_TAGS_:

--- a/io_ogre/ogre/material_parser.py
+++ b/io_ogre/ogre/material_parser.py
@@ -1,0 +1,534 @@
+
+import bpy
+import os
+import ast
+import logging
+
+logger = logging.getLogger('material_parser')
+
+class ScriptToken:
+    TID_LBRACKET = 0
+    TID_RBRACKET = 1
+    TID_COLON = 2
+    TID_VARIABLE = 3
+    TID_WORD = 4
+    TID_QUOTE = 5
+    TID_NEWLINE = 6
+    TID_UNKNOWN = 7
+    TID_END = 8
+
+    types = ["TID_LBRACKET", "TID_RBRACKET", "TID_COLON", "TID_VARIABLE", "TID_WORD", "TID_QUOTE", "TID_NEWLINE", "TID_UNKNOWN", "TID_END"]
+
+    def __init__(self, line):
+        self.line = line
+        self.type = -1
+        self.lexeme = ""
+
+    def __str__(self):
+        return("line: %s, type: %s, lexeme: %s" % (self.line, self.types[self.type], self.lexeme))
+
+class ScriptLexer:
+
+    error = ""
+    
+    def tokenize(self, str, source):
+
+        # States
+        READY = 0
+        COMMENT = 1
+        MULTICOMMENT = 2
+        WORD = 3
+        QUOTE = 4
+        VAR = 5
+        POSSIBLECOMMENT = 6
+
+        # Set up some constant characters of interest
+        varopener = '$'
+        quote = '"'
+        slash = '/'
+        backslash = '\\'
+        openbrace = '{'
+        closebrace = '}'
+        colon = ':'
+        star = '*'
+        cr = '\r'
+        lf = '\n'
+
+        c = 0
+        lastc = 0
+
+        lexeme = ""
+        line = 1
+        state = READY
+        lastQuote = 0
+        firstOpenBrace = 0
+        braceLayer = 0
+        tokens = []
+
+        # Iterate over the input
+        for i in str:
+        
+            lastc = c;
+            c = i;
+            
+            if c == quote:
+                lastQuote = line;
+            
+            if state == READY or state == WORD or state == VAR:
+                if c == openbrace:
+                    if braceLayer == 0:
+                        firstOpenBrace = line;
+                    braceLayer += 1
+
+                elif c == closebrace:
+                    if braceLayer == 0:
+                        self.error = "no matching open bracket '{' found for close bracket '}' at %s:%s" % (source, line)
+                        return tokens;
+                    braceLayer -= 1
+            
+            if state == READY:
+                if c == slash and lastc == slash:
+                    # Comment start, clear out the lexeme
+                    lexeme = ""
+                    state = COMMENT
+
+                elif c == star and lastc == slash:
+                    lexeme = ""
+                    state = MULTICOMMENT
+
+                elif c == quote:
+                    # Clear out the lexeme ready to be filled with quotes!
+                    lexeme = c
+                    state = QUOTE
+
+                elif c == varopener:
+                    # Set up to read in a variable
+                    lexeme = c
+                    state = VAR
+
+                elif self.isNewline(c):
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+
+                elif not self.isWhitespace(c):
+                    lexeme = c
+                    if c == slash:
+                        state = POSSIBLECOMMENT
+                    else:
+                        state = WORD
+
+            elif state == COMMENT:
+                if self.isNewline(c):
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+            elif state == MULTICOMMENT:
+                if c == slash and lastc == star:
+                    state = READY
+
+            elif state == POSSIBLECOMMENT:
+                if c == slash and lastc == slash:
+                    lexeme = ""
+                    state = COMMENT
+
+                elif c == star and lastc == slash:
+                    lexeme = ""
+                    state = MULTICOMMENT
+
+                else:
+                    state = WORD
+                    # OGRE_FALLTHROUGH;
+
+            elif state == WORD:
+                if self.isNewline(c):
+                    self.setToken(lexeme, line, tokens)
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                elif self.isWhitespace(c):
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                elif c == openbrace or c == closebrace or c == colon:
+                    self.setToken(lexeme, line, tokens)
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                else:
+                    lexeme += c
+
+            elif state == QUOTE:
+                if c != backslash:
+                    # Allow embedded quotes with escaping
+                    if c == quote and lastc == backslash:
+                        lexeme += c
+
+                    elif c == quote:
+                        lexeme += c
+                        self.setToken(lexeme, line, tokens)
+                        state = READY
+
+                    else:
+                        # Backtrack here and allow a backslash normally within the quote
+                        if lastc == backslash:
+                            lexeme = lexeme + "\\" + c
+                        else:
+                            lexeme += c
+
+            elif state == VAR:
+                if isNewline(c):
+                    self.setToken(lexeme, line, tokens)
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                elif isWhitespace(c):
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                elif c == openbrace or c == closebrace or c == colon:
+                    self.setToken(lexeme, line, tokens)
+                    lexeme = c
+                    self.setToken(lexeme, line, tokens)
+                    state = READY
+
+                else:
+                    lexeme += c
+
+            # Separate check for newlines just to track line numbers
+            if (c == cr or (c == lf and lastc != cr)):
+                line += 1
+
+        # Check for valid exit states
+        if state == WORD or state == VAR:
+            if lexeme != "":
+                self.setToken(lexeme, line, tokens)
+
+        else:
+            if state == QUOTE:
+                self.error = "no matching \" found for \" at %s:%s" % (source, lastQuote)
+                return tokens;
+        
+        # Check that all opened brackets have been closed
+        if braceLayer == 1:
+            self.error = "no matching closing bracket '}' for open bracket '{' at %s:%s" % (source, firstOpenBrace)
+
+        elif braceLayer > 1:
+            self.error = "too many open brackets (%d) '{' without matching closing bracket '}' in %s" % (braceLayer, source)
+
+        return tokens;
+
+    def setToken(self, lexeme, line, tokens):
+        openBracket = '{'
+        closeBracket = '}'
+        colon = ':'
+        quote = '\"'
+        var = '$'
+
+        token = ScriptToken(line)
+        token.line = line
+        ignore = False
+
+        # Check the user token map first
+        if(len(lexeme) == 1 and self.isNewline(lexeme[0])):
+            token.type = ScriptToken.TID_NEWLINE
+
+            if(len(tokens) != 0 and tokens[-1].type == ScriptToken.TID_NEWLINE):
+                ignore = True
+
+        elif(len(lexeme) == 1 and lexeme[0] == openBracket):
+            token.type = ScriptToken.TID_LBRACKET
+
+        elif(len(lexeme) == 1 and lexeme[0] == closeBracket):
+            token.type = ScriptToken.TID_RBRACKET
+
+        elif(len(lexeme) == 1 and lexeme[0] == colon):
+            token.type = ScriptToken.TID_COLON
+
+        else:
+            token.lexeme = lexeme
+
+            # This is either a non-zero length phrase or quoted phrase
+            if(len(lexeme) >= 2 and lexeme[0] == quote and lexeme[-1] == quote):
+                token.type =ScriptToken.TID_QUOTE
+
+            elif(len(lexeme) > 1 and lexeme[0] == var):
+                token.type = ScriptToken.TID_VARIABLE
+
+            else:
+                token.type = ScriptToken.TID_WORD
+
+        if(not ignore):
+            tokens.append(token)
+
+    def isWhitespace(self, c):
+        return (c == ' ' or c == '\r' or c == '\t')
+
+    def isNewline(self, c):
+        return (c == '\n' or c == '\r')
+
+
+class MaterialParser:
+
+    def unquote(string):
+        return (string[1:-1])
+    
+
+    def parameters(i, tokens):
+        parameters = []
+        j = 1
+        while tokens[i + j].type == ScriptToken.TID_WORD:
+
+            try:
+                lexeme = ast.literal_eval(tokens[i + j].lexeme)
+
+            except ValueError:
+                lexeme = tokens[i + j].lexeme
+
+            except SyntaxError:
+                lexeme = tokens[i + j].lexeme
+            
+            parameters.append(lexeme)
+
+            j += 1
+        
+        return parameters
+
+
+    def xParseMaterial(meshMaterials, materialFile, folder):
+        logger.info("* Parsing material file: %s" % materialFile)
+
+        try:
+            filein = open(materialFile)
+        except Exception:
+            logger.warning("Material: File %s not found!" % materialFile)
+            return None
+
+        data = filein.read()
+        filein.close()
+        
+        sl = ScriptLexer()
+        tokens = sl.tokenize(data, materialFile)
+        
+        if sl.error != "":
+            logger.error("ERROR: Material Script tokenizer failed with error: %s" % sl.error)
+            return None
+
+        SID_NONE = -1
+        SID_MATERIAL = 0
+        SID_TECHNIQUE = 1
+        SID_PASS = 2
+        SID_TEXTURE_UNIT = 3
+
+        state = SID_NONE
+        
+        # TODO:
+        # - RTSS Support
+
+        for i in range(0, len(tokens)):
+            token = tokens[i]
+
+            # Find Material
+            if state == SID_NONE:
+                if token.type == ScriptToken.TID_WORD and token.lexeme == "import":
+                    logger.warning("Script importing and material inheritance are not supported")
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "vertex_program":
+                    logger.warning("Vertex programs not supported, only Fixed Function Pipeline style materials")
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "fragment_program":
+                    logger.warning("Fragment programs not supported, only Fixed Function Pipeline style materials")
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "geometry_program":
+                    logger.warning("Geometry programs not supported, only Fixed Function Pipeline style materials")
+            
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "material":
+                    technique_nr = 0
+                    pass_nr = 0
+                    name = ""
+                    Material = {}
+
+                    state = SID_MATERIAL
+                    
+                    if tokens[i + 1].type == ScriptToken.TID_WORD:
+                        name = tokens[i + 1].lexeme
+
+                    elif tokens[i + 1].type == ScriptToken.TID_QUOTE:
+                        name = MaterialParser.unquote(tokens[i + 1].lexeme)
+                    
+                    else:
+                        logger.error("ERROR: Material name not found %s" % token)
+                        continue
+
+                    logger.debug("Material name: %s" % name)
+            
+            # Parse Material
+            elif state == SID_MATERIAL:
+                if token.type == ScriptToken.TID_WORD and token.lexeme == "technique":
+                    state = SID_TECHNIQUE
+
+                    technique_nr += 1
+                    
+                    if technique_nr > 1:
+                        logger.warning("Only one technique is supported")
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "receive_shadows":
+                    if tokens[i + 1].type == ScriptToken.TID_WORD and tokens[i + 1].lexeme == "on":
+                        logger.debug("receive_shadows: %s" % tokens[i + 1].lexeme)
+                        Material['receive_shadows'] = True
+                        # context.material.use_shadows = True
+
+                    elif tokens[i + 1].type == ScriptToken.TID_WORD and tokens[i + 1].lexeme == "off":
+                        logger.debug("receive_shadows: %s" % tokens[i + 1].lexeme)
+                        Material['receive_shadows'] = False
+                        # context.material.use_shadows = False
+                    
+                    else:
+                        logger.error("Parsing receive_shadows %s" % token)
+                
+                elif token.type == ScriptToken.TID_RBRACKET:
+                    state = SID_NONE
+                    
+                    if len(Material) > 0:
+                        meshMaterials[name] = Material
+                    else:
+                        logger.warning("Material %s is empty" % name)
+
+            # Parse Technique
+            elif state == SID_TECHNIQUE:
+                if technique_nr > 1 and token.type != ScriptToken.TID_RBRACKET:
+                    continue
+
+                if token.type == ScriptToken.TID_WORD and token.lexeme == "pass":
+                    state = SID_PASS
+
+                    pass_nr += 1
+                    
+                    if pass_nr > 1:
+                        logger.warning("Only one pass is supported")
+
+                elif token.type == ScriptToken.TID_RBRACKET:
+                    state = SID_MATERIAL
+
+            # Parse Pass
+            elif state == SID_PASS:
+                if pass_nr > 1 and token.type != ScriptToken.TID_RBRACKET:
+                    continue
+            
+                if token.type == ScriptToken.TID_WORD and token.lexeme == "texture_unit":
+                    state = SID_TEXTURE_UNIT
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "ambient":
+                    params = MaterialParser.parameters(i, tokens)
+                    
+                    if len(params) == 1 and tokens[i + 1].lexeme == "vertexcolour":
+                        Material['vertexcolour'] = True
+                        #context.material.use_vertex_color_paint = True
+                
+                    elif len(params) == 3 or len(params) == 4:
+                        Material['ambient'] = params
+
+                    else:
+                        logger.error("Parsing ambient: %s" % token)
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "diffuse":
+                    params = MaterialParser.parameters(i, tokens)
+                    
+                    if len(params) == 1 and tokens[i + 1].lexeme == "vertexcolour":
+                        Material['vertexcolour'] = True
+                        #context.material.use_vertex_color_paint = True
+
+                    elif len(params) == 3 or len(params) == 4:
+                        Material['diffuse'] = params
+
+                    else:
+                        logger.error("Parsing diffuse: %s" % token)
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "specular":
+                    params = MaterialParser.parameters(i, tokens)
+                    
+                    if len(params) == 1 and tokens[i + 1].lexeme == "vertexcolour":
+                        Material['vertexcolour'] = True
+                        #context.material.use_vertex_color_paint = True
+
+                    elif len(params) == 3 or len(params) == 4 or len(params) == 5:
+                        Material['specular'] = params
+                        #print("\t\tspecular: %s" % params)
+
+                    else:
+                        logger.error("Parsing specular: %s" % token)
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "emissive":
+                    params = MaterialParser.parameters(i, tokens)
+                    
+                    if len(params) == 1 and tokens[i + 1].lexeme == "vertexcolour":
+                        Material['vertexcolour'] = True
+                        #context.material.use_vertex_color_paint = True
+
+                    elif len(params) == 3 or len(params) == 4:
+                        Material['emissive'] = params
+                        #emit_intensity = (color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722) * color[3];
+                        #emit_intensity = color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722;
+                    else:
+                        logger.error("Parsing emissive: %s" % token)
+
+                elif token.type == ScriptToken.TID_WORD and token.lexeme == "depth_bias":
+                    params = MaterialParser.parameters(i, tokens)
+                    
+                    if len(params) == 1:
+                        Material['depth_bias'] = params
+                        # mat.offset_z = tokens[i + 1].lexeme
+                    else:
+                        logger.error("Parsing depth_bias: %s" % token)
+
+                elif token.type == ScriptToken.TID_RBRACKET:
+                    state = SID_TECHNIQUE
+            
+            elif state == SID_TEXTURE_UNIT:
+                if token.type == ScriptToken.TID_WORD and token.lexeme == "texture":
+                    if tokens[i + 1].type == ScriptToken.TID_WORD:
+                        imageName = tokens[i + 1].lexeme
+
+                    elif tokens[i + 1].type == ScriptToken.TID_QUOTE:
+                        imageName = self.unquote(tokens[i + 1].lexeme)
+                    
+                    else:
+                        logger.error("Texture name not found: %s" % token)
+                        continue
+                        
+                    file = os.path.join(folder, imageName)
+                    if(not os.path.isfile(file)):
+                        # Just force to use .dds if there isn't a file specified in the material file
+                        file = os.path.join(folder, os.path.splitext(imageName)[0] + ".dds")
+                        if(os.path.isfile(file)):
+                            Material['texture'] = file
+                            Material['imageNameOnly'] = imageName
+                        else:
+                            logger.warning("Referenced texture '%s' not found" % imageName)
+                    else:
+                        Material['texture'] = file
+                        Material['imageNameOnly'] = imageName
+            
+                elif token.type == ScriptToken.TID_RBRACKET:
+                    state = SID_PASS
+
+
+    def xCollectMaterialData(meshData, onlyName, folder):
+
+        meshMaterials = {}
+        nameDotMaterial = onlyName + ".material"
+        pathMaterial = os.path.join(folder, nameDotMaterial)
+        if not os.path.isfile(pathMaterial):
+            # Search directory for .material
+            for filename in os.listdir(folder):
+                if ".material" in filename:
+                    # Material file
+                    pathMaterial = os.path.join(folder, filename)
+                    MaterialParser.xParseMaterial(meshMaterials, pathMaterial, folder)
+        else:
+            MaterialParser.xParseMaterial(meshMaterials, pathMaterial, folder)
+        
+        meshData['materials'] = meshMaterials

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -1,6 +1,22 @@
 import os, time, sys, logging
 import bmesh
 import mathutils
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "report" in locals():
+        importlib.reload(report)
+    if "material" in locals():
+        importlib.reload(material)
+    if "util" in locals():
+        importlib.reload(util)
+    if "xml" in locals():
+        importlib.reload(xml)
+    if "skeleton.Skeleton" in locals():
+        importlib.reload(skeleton.Skeleton)
+
 from ..report import Report
 from ..util import *
 from ..xml import *
@@ -157,10 +173,12 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         # Create bmesh to help obtain custom vertex normals
         bm = bmesh.new()
         if mesh.has_custom_normals:
+            logger.debug(" * Mesh has custom normals")
             mesh.calc_normals_split()
             bm.from_mesh(mesh)
             bm.verts.ensure_lookup_table()
         else:
+            logger.debug(" * Mesh has NO custom normals")
             bm.from_mesh(mesh)
 
         # Ogre only supports triangles
@@ -183,12 +201,17 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
             mesh.calc_tangents(uvmap=mesh.uv_layers.active.name)
 
         progressScale = 1.0 / len(mesh.polygons)
+        bpy.context.window_manager.progress_begin(0, 100)
         
         # Process mesh after triangulation
         for F in mesh.polygons:
+            # Update progress in console
             percent = (F.index + 1) * progressScale
             sys.stdout.write( "\r + Faces [" + '=' * int(percent * 50) + '>' + '.' * int(50 - percent * 50) + "] " + str(int(percent * 10000) / 100.0) + "%   ")
             sys.stdout.flush()
+            
+            # Update progress through Blender cursor
+            bpy.context.window_manager.progress_update(percent)
             
             smooth = F.use_smooth
             tri = (F.vertices[0], F.vertices[1], F.vertices[2])
@@ -309,7 +332,8 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         doc.end_tag('vertexbuffer')
         doc.end_tag('sharedgeometry')
 
-        print("")
+        sys.stdout.write("")
+
         logger.info('- Done at %s seconds' % timer_diff_str(start))
         logger.info('* Writing submeshes')
 

--- a/io_ogre/ogre/ogre_import.py
+++ b/io_ogre/ogre/ogre_import.py
@@ -1,0 +1,1419 @@
+#!BPY
+
+"""
+Name: 'OGRE for Kenshi (*.MESH)'
+Blender: 2.63a, 2.77a, 2.79
+Group: 'Import/Export'
+Tooltip: 'Import/Export Kenhi OGRE mesh files'
+
+Author: Someone
+
+Based on the Torchlight Impost/Export script by 'Dusho'
+
+Thanks goes to 'goatman' for his port of Ogre export script from 2.49b to 2.5x,
+and 'CCCenturion' for trying to refactor the code to be nicer (to be included)
+"""
+
+__author__ = "someone"
+__version__ = "0.8.15 17-Jul-2019"
+
+__bpydoc__ = """\
+This script imports/exports Kenshi Ogre models into/from Blender.
+
+Supported:<br>
+    * import/export of basic meshes
+    * import/export of skeleton
+    * import/export of animations
+    * import/export of vertex weights (ability to import characters and adjust rigs)
+    * import/export of vertex colour (RGB)
+    * import/export of vertex alpha (Uses second vertex colour layer called Alpha)
+    * import/export of shape keys
+    * Calculation of tangents and binormals for export
+
+Known issues:<br>
+    * imported materials will lose certain informations not applicable to Blender when exported
+
+History:<br>
+    * v0.8.15  (17-Jul-2019) - Added option to import normals
+    * v0.8.14  (14-May-2019) - Fixed blender deleting zero length bones
+    * v0.8.13  (19-Mar-2019) - Exporting material files is optional
+    * v0.8.12  (14-Mar-2019) - Fixed error exporting animation scale keyframes
+    * v0.8.11  (26-Feb-2019) - Fixed tangents and binormals for mirrorred uvs
+    * v0.8.10  (32-Jan-2019) - Fixed export when mesh has multiple uv sets
+    * v0.8.9   (08-Mar-2018) - Added import option to match weight maps and link with a previously imported skeleton
+    * v0.8.8   (26-Feb-2018) - Fixed export triangulation and custom normals
+    * v0.8.7   (01-Feb-2018) - Scene frame rate adjusted on import, Fixed quatenion normalisation
+    * v0.8.6   (31-Jan-2018) - Fixed crash exporting animations in blender 2.79
+    * v0.8.5   (02-Jan-2018) - Optimisation: Use hashmap for duplicate vertex detection
+    * v0.8.4   (20-Nov-2017) - Fixed animation quaternion interpolation
+    * v0.8.3   (06-Nov-2017) - Warning when linked skeleton file not found
+    * v0.8.2   (25-Sep-2017) - Fixed bone translations in animations
+    * v0.8.1   (28-Jul-2017) - Added alpha component to vertex colour
+    * v0.8.0   (30-Jun-2017) - Added animation and shape key support. Rewritten skeleton export
+    * v0.7.2   (08-Dec-2016) - fixed divide by 0 error calculating tangents
+    * v0.7.1   (07-Sep-2016) - bug fixes
+    * v0.7.0   (02-Sep-2016) - Implemented changes needed for Kenshi: Persistant Ogre bone IDs, Export vertex colours. Generates tangents and binormals.
+    * v0.6.2   (09-Mar-2013) - bug fixes (working with materials+textures), added 'Apply modifiers' and 'Copy textures'
+    * v0.6.1   (27-Sep-2012) - updated to work with Blender 2.63a
+    * v0.6     (01-Sep-2012) - added skeleton import + vertex weights import/export
+    * v0.5     (06-Mar-2012) - added material import/export
+    * v0.4.1   (29-Feb-2012) - flag for applying transformation, default=true
+    * v0.4     (28-Feb-2012) - fixing export when no UV data are present
+    * v0.3     (22-Feb-2012) - WIP - started cleaning + using OgreXMLConverter
+    * v0.2     (19-Feb-2012) - WIP - working export of geometry and faces
+    * v0.1     (18-Feb-2012) - initial 2.59 import code (from .xml)
+    * v0.0     (12-Feb-2012) - file created
+"""
+
+"""
+When importing: (x)-Blender, (x')-Ogre
+vectors: x=x', y=-z', z=y'
+UVtex: u=u', v = -v'+1
+
+Inner data representation:
+MESHDATA:
+['sharedgeometry']: {}
+    ['positions'] - vectors with [x,y,z]
+    ['normals'] - vectors with [x,y,z]
+    ['vertexcolors'] - vectors with [r,g,b,a]
+    ['texcoordsets'] - integer (number of UV sets)
+    ['uvsets'] - vectors with [u,v] * number or UV sets for vertex [[u,v]][[u,v]]...
+    ['boneassignments']: {[boneName]} - for every bone name:
+        [[vertexNumber], [weight]], [[vertexNumber], [weight]],  ..
+['submeshes'][idx]
+        [material] - string (material name)
+        [materialOrg] - original material name - for searching the in shared materials file
+        [faces] - vectors with faces [v1,v2,v3]
+        [geometry] - identical to 'sharedgeometry' data content
+['materials']
+    [(matID)]: {}
+        ['texture'] - full path to texture file
+        ['imageNameOnly'] - only image name from material file
+['skeleton']: {[boneName]} for each bone
+        ['name'] - bone name
+        ['id'] - bone ID
+        ['position'] - bone position [x,y,z]
+        ['rotation'] - bone rotation [x,y,z,angle]
+        ['parent'] - bone name of parent bone
+        ['children'] - list with names if children ([child1, child2, ...])
+['boneIDs']: {[bone ID]:[bone Name]} - dictionary with ID to name
+['skeletonName'] - name of skeleton
+
+Note: Bones store their OGREID as a custom variable so they are consistent when a mesh is exported
+"""
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "material_parser" in locals():
+        importlib.reload(material_parser.MaterialParser)
+
+#from Blender import *
+import bpy
+from xml.dom import minidom
+from mathutils import Vector, Matrix
+import math, os, subprocess
+from .material_parser import MaterialParser
+from .. import config
+from .. import util
+from ..report import Report
+from ..util import *
+
+logger = logging.getLogger('ogre_import')
+
+# Script internal options:
+SHOW_IMPORT_DUMPS = False
+SHOW_IMPORT_TRACE = False   # 
+MIN_BONE_LENGTH = 0.00001	# Prevent automatic removal of bones
+
+# Default blender version of script
+blender_version = 259
+
+# Makes sure name doesn't exceed Blenders naming limits
+# Also keeps after name (as Torchlight uses names to identify types -boots, chest, ...- with names)
+# TODO: This is not needed for Blender 2.62 and above
+def GetValidBlenderName(name):
+
+    global blender_version
+
+    newname = name.strip()
+    
+    maxChars = 20
+    if blender_version > 262:
+        maxChars = 63
+
+    if(len(name) > maxChars):
+        if(name.find("/") >= 0):
+            if(name.find("Material") >= 0):
+                # Replace 'Material' string with only 'Mt'
+                newname = name.replace("Material", "Mt")
+            # Check if it's still above 20
+            if(len(newname) > maxChars):
+                suffix = newname[newname.find("/"):]
+                prefix = newname[0:(maxChars+1-len(suffix))]
+                newname = prefix + suffix
+        else:
+            newname = name[0 : maxChars + 1]
+
+    if(newname != name):
+        logger.warning("Name truncated (%s -> %s)" % (name, newname))
+
+    return newname
+
+def xOpenFile(filename):
+    xml_file = open(filename)
+    try:
+        xml_doc = minidom.parse(xml_file)
+        output = xml_doc
+    except Exception:
+        logger.error("File %s is not valid XML!" % filename)
+        Report.errors.append("File %s is not valid XML!" % filename)
+        output = 'None'
+    xml_file.close()
+    return output
+
+
+def xCollectFaceData(facedata):
+    faces = []
+    for face in facedata.childNodes:
+        if face.localName == 'face':
+            v1 = int(face.getAttributeNode('v1').value)
+            v2 = int(face.getAttributeNode('v2').value)
+            v3 = int(face.getAttributeNode('v3').value)
+            faces.append([v1, v2, v3])
+
+    return faces
+
+
+def xCollectVertexData(data):
+    vertexdata = {}
+    vertices = []
+    normals = []
+    vertexcolors = []
+    
+    for vb in data.childNodes:
+        if vb.localName == 'vertexbuffer':
+            if vb.hasAttribute('positions'):
+                for vertex in vb.getElementsByTagName('vertex'):
+                    for vp in vertex.childNodes:
+                        if vp.localName == 'position':
+                            x = float(vp.getAttributeNode('x').value)
+                            y = -float(vp.getAttributeNode('z').value)
+                            z = float(vp.getAttributeNode('y').value)
+                            vertices.append([x, y, z])
+                vertexdata['positions'] = vertices
+
+            if vb.hasAttribute('normals') and config.get('IMPORT_NORMALS'):
+                for vertex in vb.getElementsByTagName('vertex'):
+                    for vn in vertex.childNodes:
+                        if vn.localName == 'normal':
+                            x = float(vn.getAttributeNode('x').value)
+                            y = -float(vn.getAttributeNode('z').value)
+                            z = float(vn.getAttributeNode('y').value)
+                            normals.append([x, y, z])
+                vertexdata['normals'] = normals
+
+            if vb.hasAttribute('colours_diffuse'):
+                for vertex in vb.getElementsByTagName('vertex'):
+                    for vcd in vertex.childNodes:
+                        if vcd.localName == 'colour_diffuse':
+                            rgba = vcd.getAttributeNode('value').value
+                            r = float(rgba.split()[0])
+                            g = float(rgba.split()[1])
+                            b = float(rgba.split()[2])
+                            a = float(rgba.split()[3])
+                            vertexcolors.append([r, g, b, a])
+                vertexdata['vertexcolors'] = vertexcolors
+
+            if vb.hasAttribute('texture_coord_dimensions_0'):
+                texcosets = int(vb.getAttributeNode('texture_coords').value)
+                vertexdata['texcoordsets'] = texcosets
+                uvcoordset = []
+                for vertex in vb.getElementsByTagName('vertex'):
+                    uvcoords = []
+                    for vt in vertex.childNodes:
+                        if vt.localName == 'texcoord':
+                            u = float(vt.getAttributeNode('u').value)
+                            v = -float(vt.getAttributeNode('v').value)+1.0
+                            uvcoords.append([u, v])
+
+                    if len(uvcoords) > 0:
+                        uvcoordset.append(uvcoords)
+                vertexdata['uvsets'] = uvcoordset
+    
+    return vertexdata
+
+
+def xCollectMeshData(meshData, xmldoc, meshname, dirname):
+    logger.info("* Collecting mesh data...")
+    
+    # Global has_skeleton
+    faceslist = []
+    subMeshData = []
+    allObjs = []
+    isSharedGeometry = False
+    sharedGeom = []
+    hasSkeleton = 'boneIDs' in meshData
+
+    # Collect shared geometry
+    if(len(xmldoc.getElementsByTagName('sharedgeometry')) > 0):
+        isSharedGeometry = True
+        for subnodes in xmldoc.getElementsByTagName('sharedgeometry'):
+            meshData['sharedgeometry'] = xCollectVertexData(subnodes)
+
+        if hasSkeleton:
+            for subnodes in xmldoc.getElementsByTagName('boneassignments'):
+                meshData['sharedgeometry']['boneassignments'] = xCollectBoneAssignments(meshData, subnodes)
+
+    # Collect submeshes data
+    for submeshes in xmldoc.getElementsByTagName('submeshes'):
+        for submesh in submeshes.childNodes:
+            if submesh.localName == 'submesh':
+                materialOrg = str(submesh.getAttributeNode('material').value)
+                # To avoid Blender naming limit problems
+                material = GetValidBlenderName(materialOrg)
+                sm = {}
+                sm['material'] = material
+                sm['materialOrg'] = materialOrg
+                for subnodes in submesh.childNodes:
+                    if subnodes.localName == 'faces':
+                        facescount = int(subnodes.getAttributeNode('count').value)
+                        sm['faces'] = xCollectFaceData(subnodes)
+
+                        if len(xCollectFaceData(subnodes)) != facescount:
+                            logger.debug("FacesCount doesn't match!")
+                            break
+
+                    if (subnodes.localName == 'geometry'):
+                        vertexcount = int(subnodes.getAttributeNode('vertexcount').value)
+                        sm['geometry'] = xCollectVertexData(subnodes)
+
+                    if hasSkeleton and subnodes.localName == 'boneassignments' and isSharedGeometry==False:
+                        sm['geometry']['boneassignments'] = xCollectBoneAssignments(meshData, subnodes)
+
+                subMeshData.append(sm)
+
+    meshData['submeshes'] = subMeshData
+
+    return meshData
+
+
+def xCollectBoneAssignments(meshData, xmldoc):
+    boneIDtoName = meshData['boneIDs']
+
+    VertexGroups = {}
+    for vg in xmldoc.childNodes:
+        if vg.localName == 'vertexboneassignment':
+            VG = str(vg.getAttributeNode('boneindex').value)
+            if VG in boneIDtoName.keys():
+                VGNew = boneIDtoName[VG]
+            else:
+                VGNew = 'Group ' + VG
+            if VGNew not in VertexGroups.keys():
+                VertexGroups[VGNew] = []
+
+    for vg in xmldoc.childNodes:
+        if vg.localName == 'vertexboneassignment':
+
+            VG = str(vg.getAttributeNode('boneindex').value)
+            if VG in boneIDtoName.keys():
+                VGNew = boneIDtoName[VG]
+            else:
+                VGNew = VG
+            verti = int(vg.getAttributeNode('vertexindex').value)
+            weight = float(vg.getAttributeNode('weight').value)
+            # logger.debug("bone=%s, vert=%s, weight=%s" % (VGNew, verti, weight))
+            VertexGroups[VGNew].append([verti, weight])
+
+    return VertexGroups
+
+
+def xCollectPoseData(meshData, xmldoc):
+    logger.info("* Collecting pose data...")
+    
+    poses = xmldoc.getElementsByTagName('pose')
+    if(len(poses) > 0):
+        meshData['poses'] = []
+    for pose in poses:
+        name = pose.getAttribute('name')
+        target = pose.getAttribute('target')
+        index = pose.getAttribute('index')
+        if target == 'submesh':
+            poseData = {}
+            poseData['name'] = name
+            poseData['submesh'] = int(index)
+            poseData['data'] = data = []
+            meshData['poses'].append(poseData)
+            for value in pose.getElementsByTagName('poseoffset'):
+                index = int(value.getAttribute('index'))
+                x = float(value.getAttribute('x'))
+                y = float(value.getAttribute('y'))
+                z = float(value.getAttribute('z'))
+                data.append((index, x, -z, y))
+
+
+def xGetSkeletonLink(xmldoc, folder):
+    skeletonFile = "None"
+    if(len(xmldoc.getElementsByTagName("skeletonlink")) > 0):
+        # Get the skeleton link of the mesh
+        skeletonLink = xmldoc.getElementsByTagName("skeletonlink")[0]
+        skeletonName = skeletonLink.getAttribute("name")
+        skeletonFile = os.path.join(folder, skeletonName)
+        # Check for existence of skeleton file
+        if not os.path.isfile(skeletonFile):
+            Report.warnings.append("Cannot find linked skeleton file '%s'\nIt must be in the same directory as the mesh file." % skeletonName)
+            logger.warning("Ogre skeleton missing: %s" % skeletonFile)
+            skeletonFile = "None"
+
+    return skeletonFile
+
+
+# def xCollectBoneData(meshData, xDoc, name, folder):
+def xCollectBoneData(meshData, xDoc):
+    logger.info("* Collecting bone data...")
+    
+    OGRE_Bones = {}
+    BoneIDToName = {}
+    meshData['skeleton'] = OGRE_Bones
+    meshData['boneIDs'] = BoneIDToName
+
+    for bones in xDoc.getElementsByTagName('bones'):
+        for bone in bones.childNodes:
+            OGRE_Bone = {}
+            if bone.localName == 'bone':
+                boneName = str(bone.getAttributeNode('name').value)
+                boneID = int(bone.getAttributeNode('id').value)
+                OGRE_Bone['name'] = boneName
+                OGRE_Bone['id'] = boneID
+                BoneIDToName[str(boneID)] = boneName
+
+                for b in bone.childNodes:
+                    if b.localName == 'position':
+                        x = float(b.getAttributeNode('x').value)
+                        y = float(b.getAttributeNode('y').value)
+                        z = float(b.getAttributeNode('z').value)
+                        OGRE_Bone['position'] = [x, y, z]
+                    if b.localName == 'rotation':
+                        angle = float(b.getAttributeNode('angle').value)
+                        axis = b.childNodes[1]
+                        axisx = float(axis.getAttributeNode('x').value)
+                        axisy = float(axis.getAttributeNode('y').value)
+                        axisz = float(axis.getAttributeNode('z').value)
+                        OGRE_Bone['rotation'] = [axisx, axisy, axisz, angle]
+
+                OGRE_Bones[boneName] = OGRE_Bone
+
+    for bonehierarchy in xDoc.getElementsByTagName('bonehierarchy'):
+        for boneparent in bonehierarchy.childNodes:
+            if boneparent.localName == 'boneparent':
+                Bone = str(boneparent.getAttributeNode('bone').value)
+                Parent = str(boneparent.getAttributeNode('parent').value)
+                OGRE_Bones[Bone]['parent'] = Parent
+
+    # Update Ogre bones with list of children
+    calcBoneChildren(OGRE_Bones)
+
+    # Helper bones
+    calcHelperBones(OGRE_Bones)
+    calcZeroBones(OGRE_Bones)
+
+    # Update Ogre bones with head positions
+    calcBoneHeadPositions(OGRE_Bones)
+
+    # Update Ogre bones with rotation matrices
+    calcBoneRotations(OGRE_Bones)
+    
+    return OGRE_Bones
+
+
+def calcBoneChildren(BonesData):
+    for bone in BonesData.keys():
+        childlist = []
+        for key in BonesData.keys():
+            if 'parent' in BonesData[key]:
+                parent = BonesData[key]['parent']
+                if parent == bone:
+                    childlist.append(key)
+        BonesData[bone]['children'] = childlist
+
+
+def calcHelperBones(BonesData):
+    count = 0
+    helperBones = {}
+    for bone in BonesData.keys():
+        if ((len(BonesData[bone]['children']) == 0) or
+                (len(BonesData[bone]['children']) > 1)):
+            HelperBone = {}
+            HelperBone['position'] = [0.2, 0.0, 0.0]
+            HelperBone['parent'] = bone
+            HelperBone['rotation'] = [1.0, 0.0, 0.0, 0.0]
+            HelperBone['flag'] = 'helper'
+            HelperBone['name'] = 'Helper' + str(count)
+            HelperBone['children'] = []
+            helperBones['Helper' + str(count)] = HelperBone
+            count += 1
+    for hBone in helperBones.keys():
+        BonesData[hBone] = helperBones[hBone]
+
+
+def calcZeroBones(BonesData):
+    zeroBones = {}
+    for bone in BonesData.keys():
+        pos = BonesData[bone]['position']
+        if (math.sqrt(pos[0]**2 + pos[1]**2 + pos[2]**2)) == 0:
+            ZeroBone = {}
+            ZeroBone['position'] = [0.2, 0.0, 0.0]
+            ZeroBone['rotation'] = [1.0, 0.0, 0.0, 0.0]
+            if 'parent' in BonesData[bone]:
+                ZeroBone['parent'] = BonesData[bone]['parent']
+            ZeroBone['flag'] = 'zerobone'
+            ZeroBone['name'] = 'Zero' + bone
+            ZeroBone['children'] = []
+            zeroBones['Zero' + bone] = ZeroBone
+            if 'parent' in BonesData[bone]:
+                BonesData[BonesData[bone]['parent']]['children'].append('Zero' + bone)
+    for hBone in zeroBones.keys():
+        BonesData[hBone] = zeroBones[hBone]
+
+
+def calcBoneHeadPositions(BonesData):
+    for key in BonesData.keys():
+
+        start = 0
+        thisbone = key
+        posh = BonesData[key]['position']
+        #print("SetBonesASPositions: bone=%s, org. position=%s" % (key, posh))
+        while start == 0:
+            if 'parent' in BonesData[thisbone]:
+                parentbone = BonesData[thisbone]['parent']
+                prot = BonesData[parentbone]['rotation']
+                ppos = BonesData[parentbone]['position']
+
+                #protmat = RotationMatrix(math.degrees(prot[3]), 3, 'r', Vector(prot[0], prot[1], prot[2])).invert()
+                protmat = Matrix.Rotation(math.degrees(prot[3]), 3, Vector([prot[0], prot[1], prot[2]])).inverted()
+                #print ("SetBonesASPositions: bone=%s, protmat=%s" % (key, protmat))
+                #print(protmat)
+                #newposh = protmat * Vector([posh[0], posh[1], posh[2]])
+                #newposh = protmat * Vector([posh[2], posh[1], posh[0]]) #02
+                newposh = protmat.transposed() * Vector([posh[0], posh[1], posh[2]]) #03
+                #print("SetBonesASPositions: bone=%s, newposh=%s" % (key, newposh))
+                positionh = VectorSum(ppos,newposh)
+
+                posh = positionh
+
+                thisbone = parentbone
+            else:
+                start = 1
+
+        BonesData[key]['posHAS'] = posh
+        #print("SetBonesASPositions: bone=%s, posHAS=%s" % (key, posh))
+
+def calcBoneRotations(BonesDic):
+    objDic = {}
+    scn = bpy.context.scene
+    #scn = Scene.GetCurrent()
+    for bone in BonesDic.keys():
+        #obj = Object.New('Empty',bone)
+        obj = bpy.data.objects.new(bone, None)
+        objDic[bone] = obj
+        scn.objects.link(obj)
+    #print("all objects created")
+    #print(bpy.data.objects)
+    for bone in BonesDic.keys():
+        if 'parent' in BonesDic[bone]:
+            #Parent = Object.Get(BonesDic[bone]['parent'])
+            #print(BonesDic[bone]['parent'])
+            Parent = objDic.get(BonesDic[bone]['parent'])
+            object = objDic.get(bone)
+            object.parent = Parent
+            #Parent.makeParent([object])
+    #print("all parents linked")
+    for bone in BonesDic.keys():
+        obj = objDic.get(bone)
+        rot = BonesDic[bone]['rotation']
+        loc = BonesDic[bone]['position']
+        #print ("CreateEmptys:bone=%s, rot=%s" % (bone, rot))
+        #print ("CreateEmptys:bone=%s, loc=%s" % (bone, loc))
+        euler = Matrix.Rotation(rot[3], 3, Vector([rot[0], -rot[2], rot[1]])).to_euler()
+        obj.location = [loc[0], -loc[2], loc[1]]
+        #print ("CreateEmptys:bone=%s, euler=%s" % (bone, euler))
+        #print ("CreateEmptys:bone=%s, obj.rotation_euler=%s" % (bone,[math.radians(euler[0]),math.radians(euler[1]),math.radians(euler[2])]))
+        #obj.rotation_euler = [math.radians(euler[0]),math.radians(euler[1]),math.radians(euler[2])]
+        #print ("CreateEmptys:bone=%s, obj.rotation_euler=%s" % (bone,[euler[0],euler[1],euler[2]])) # 02
+        obj.rotation_euler = [euler[0], euler[1], euler[2]] # 02
+    # Redraw()
+    scn.update()
+    # print("all objects rotated")
+    for bone in BonesDic.keys():
+        obj = objDic.get(bone)
+        # TODO: need to get rotation matrix out of objects rotation
+        # loc, rot, scale = obj.matrix_local.decompose()
+        loc, rot, scale = obj.matrix_world.decompose() #02
+        rotmatAS = rot.to_matrix()
+        # print(rotmatAS)
+        #obj.rotation_quaternion.
+        #rotmatAS = Matrix(.matrix_local..getMatrix().rotationPart()
+        BonesDic[bone]['rotmatAS'] = rotmatAS
+        #print ("CreateEmptys:bone=%s, rotmatAS=%s" % (bone, rotmatAS))
+    # print("all matrices stored")
+
+    #for bone in BonesDic.keys():
+    #    obj = objDic.get(bone)
+    #    scn.objects.unlink(obj)
+    #    del obj
+
+    # TODO cyclic
+    for bone in BonesDic.keys():
+        obj = objDic.get(bone)
+        #obj.select = True
+        #bpy.ops.object.select_name(bone, False)
+        #bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
+        scn.objects.unlink(obj) # TODO: cyclic message in console
+        #del obj
+        #bpy.context.scene.objects.unlink(obj)
+        bpy.data.objects.remove(obj)
+
+    scn.update()
+    #removedObj = {}
+    #children=1
+    #while children > 0:
+    #    children = 0
+    #    for bone in BonesDic.keys():
+    #        if('children' in BonesDic[bone].keys() and bone not in removedObj):
+    #            if len(BonesDic[bone]['children'])==0:
+    #                obj = objDic.get(bone)
+    #                scn.objects.unlink(obj)
+    #                del obj
+    #                removedObj[bone]=True
+    #            else:
+    #                children+=1
+
+    #print("all objects removed")
+
+def VectorSum(vec1, vec2):
+    vecout = [0, 0, 0]
+    vecout[0] = vec1[0] + vec2[0]
+    vecout[1] = vec1[1] + vec2[1]
+    vecout[2] = vec1[2] + vec2[2]
+
+    return vecout
+
+## =========================================================================================== ##
+def quaternionFromAngleAxis(angle, x, y, z):
+    r = angle * 0.5
+    s = math.sin(r)
+    c = math.cos(r)
+    return (c, x*s, y*s, z*s)
+
+
+def xGetChild(node, tag):
+    for n in node.childNodes:
+        if n.nodeType == 1 and n.tagName == tag:
+            return n
+    return None
+
+
+def xAnalyseFPS(xDoc):
+    fps = 0
+    lastTime = 1e8
+    samples = 0
+    for container in xDoc.getElementsByTagName('animations'):
+        for animation in container.childNodes:
+            if animation.nodeType == 1 and animation.tagName == 'animation':
+                tracks = xGetChild(animation, 'tracks')
+                for track in tracks.childNodes:
+                    if track.nodeType == 1:
+                        for keyframe in xGetChild(track, 'keyframes').childNodes:
+                            if keyframe.nodeType == 1:
+                                time = float(keyframe.getAttribute('time'))
+                                if time > lastTime:
+                                    fps = max(fps, 1 / (time - lastTime))
+                                lastTime = time
+                                samples = samples + 1
+                                if samples > 100:
+                                    return round(fps, 2)    # stop here
+    return round(fps, 2)
+
+
+def xCollectAnimations(meshData, xDoc):
+    logger.info("* Collecting animation data...")
+    
+    if 'animations' not in meshData:
+        meshData['animations'] = {}
+    for container in xDoc.getElementsByTagName('animations'):
+        for animation in container.childNodes:
+            if animation.nodeType == 1 and animation.tagName == 'animation':
+                name = animation.getAttribute('name')
+
+                # read action data
+                action = {}
+                tracks = xGetChild(animation, 'tracks')
+                xReadAnimation(action, tracks.childNodes)
+                meshData['animations'][name] = action
+
+
+def xReadAnimation(action, tracks):
+    fps = bpy.context.scene.render.fps
+    for track in tracks:
+        if track.nodeType != 1:
+            continue
+        target = track.getAttribute('bone')
+        action[target] = trackData = [[] for i in range(3)]  # pos, rot, scl
+        for keyframe in xGetChild(track, 'keyframes').childNodes:
+            if keyframe.nodeType != 1:
+                continue
+            time = float(keyframe.getAttribute('time'))
+            frame = time * fps
+            if config.get('ROUND_FRAMES'):
+                frame = round(frame)
+            for key in keyframe.childNodes:
+                if key.nodeType != 1:
+                    continue
+                if key.tagName == 'translate':
+                    x = float(key.getAttribute('x'))
+                    y = float(key.getAttribute('y'))
+                    z = float(key.getAttribute('z'))
+                    trackData[0].append([frame, (x, y, z)])
+                elif key.tagName == 'rotate':
+                    axis = xGetChild(key, 'axis')
+                    angle = key.getAttribute('angle')
+                    x = axis.getAttribute('x')
+                    y = axis.getAttribute('y')
+                    z = axis.getAttribute('z')
+                    # skip if axis contains #INF or #IND
+                    if '#' not in x and '#' not in y and '#' not in z:
+                        quat = quaternionFromAngleAxis(float(angle), float(z), float(x), float(y))
+                        trackData[1].append([frame, quat])
+                elif key.tagName == 'scale':
+                    x = float(key.getAttribute('x'))
+                    y = float(key.getAttribute('y'))
+                    z = float(key.getAttribute('z'))
+                    trackData[2].append([frame, (-x, z, y)])
+
+
+def bCreateAnimations(meshData):
+    path_id = ['location', 'rotation_quaternion', 'scale']
+
+    if 'animations' in meshData:
+        logger.info("+ Creating animations...")
+        
+        rig = meshData['rig']
+        rig.animation_data_create()
+        animdata = rig.animation_data
+
+        # calculate transformation matrices for translation
+        mat = {}
+        fix1 = Matrix([(1, 0, 0), (0, 0, 1), (0, -1, 0)])
+        fix2 = Matrix([(0, 1, 0), (0, 0, 1), (1, 0, 0)])
+        for bone in rig.pose.bones:
+            if bone.parent: 
+            	mat[bone.name] = fix2 * bone.parent.matrix.to_3x3().transposed() * bone.matrix.to_3x3()
+            else: 
+            	mat[bone.name] = fix1 * bone.matrix.to_3x3()
+        
+        for name in sorted(meshData['animations'].keys(), reverse=True):
+            action = bpy.data.actions.new(name)
+            Report.armature_animations.append(name)
+            
+            # action.use_fake_user = True   # Dont need this as we are adding them to the nla editor
+            logger.info("+ Created action: %s" % name)
+
+            # Iterate target bones
+            for target in meshData['animations'][name]:
+                data = meshData['animations'][name][target]
+                bone = rig.pose.bones[target]
+                if not bone:
+                    continue  # error
+                bone.rotation_mode = 'QUATERNION'
+
+                # Fix rotation inversions
+                for i in range(1, len(data[1])):
+                    a = data[1][i-1][1]
+                    b = data[1][i][1]
+                    dot = a[0]*b[0] + a[1]*b[1] + a[2]*b[2] + a[3]*b[3]
+                    if dot < -0.8:
+                        #print('fix inversion', name, target, i)
+                        data[1][i][1] = (-b[0], -b[1], -b[2], -b[3])
+
+                # Fix translation keys - rotate by inverse rest orientation
+                m = mat[target].transposed()
+                for i in range(0, len(data[0])):
+                    v = Vector(data[0][i][1])
+                    data[0][i][1] = m * v
+
+                # Create fcurves
+                for i in range(3):
+                    if data[i]:
+                        path = bone.path_from_id(path_id[i])
+                        for channel in range(len(data[i][0][1])):
+                            curve = action.fcurves.new(path, channel, bone.name)
+                            for key in data[i]:
+                                curve.keyframe_points.insert(key[0], key[1][channel])
+
+            # Add action to NLA track
+            track = animdata.nla_tracks.new()
+            track.name = name
+            track.mute = True
+            track.strips.new(name, 0, action)
+
+###############################################################################
+
+def bCreateMesh(meshData, folder, name, filepath):
+    if 'skeleton' in meshData:
+        skeletonName = meshData['skeletonName']
+        bCreateSkeleton(meshData, skeletonName)
+
+    logger.info("+ Creating mesh: %s" % name)
+    
+    # From collected data create all sub meshes
+    subObjs = bCreateSubMeshes(meshData, name)
+    # Skin submeshes
+    #bSkinMesh(subObjs)
+    
+    # Move to parent skeleton if there
+    if 'armature' in meshData:
+        arm = meshData['armature']
+        for obj in subObjs:
+            logger.debug('Move to %s' % arm.location)
+            obj.location = arm.location
+            obj.rotation_euler = arm.rotation_euler
+            obj.rotation_axis_angle = arm.rotation_axis_angle
+            obj.rotation_quaternion = arm.rotation_quaternion
+
+    # Temporarily select all imported objects
+    for subOb in subObjs:
+        subOb.select = True
+    
+    # TODO: Try to merge everything into the armature object
+    if config.get('MERGE_SUBMESHES') == True:
+        #bpy.context.scene.objects.active = bpy.data.objects["Cube"]
+        bpy.ops.object.join()
+        ob = bpy.context.scene.objects.active
+        ob.name = name
+        ob.data.name = name
+
+    if SHOW_IMPORT_DUMPS:
+        importDump = filepath + "IDump"
+        fileWr = open(importDump, 'w')
+        fileWr.write(str(meshData))
+        fileWr.close()
+
+
+def bCreateSkeleton(meshData, name):
+    if 'skeleton' not in meshData:
+        return
+    bonesData = meshData['skeleton']
+    
+    logger.info("+ Creating skeleton: %s" % name)
+
+    # Create Armature
+    amt = bpy.data.armatures.new(name)
+    rig = bpy.data.objects.new(name, amt)
+    meshData['rig'] = rig
+    #rig.location = origin
+    rig.show_x_ray = True
+    #amt.show_names = True
+    # Link object to scene
+    scn = bpy.context.scene
+    scn.objects.link(rig)
+    scn.objects.active = rig
+    scn.update()
+    
+    # Chose default length of bones with no children
+    averageBone = 0
+    for b in bonesData.values():
+        childLength = b['position'][0]
+        averageBone += childLength
+    averageBone /= len(bonesData)
+    if averageBone == 0:
+        averageBone = 0.2
+    logger.debug("Default bone length: %s" % averageBone)
+
+    bpy.ops.object.mode_set(mode='EDIT')
+    for bone in bonesData.keys():
+        boneData = bonesData[bone]
+        boneName = boneData['name']
+
+        children = boneData['children']
+        boneObj = amt.edit_bones.new(boneName)
+
+        # Store Ogre bone id to match when exporting
+        if 'id' in boneData:
+            boneObj['OGREID'] = boneData['id']
+            logger.debug("BoneID: %s, BoneName: %s" % (boneData['id'], boneName))
+
+        # boneObj.head = boneData['posHAS']
+        # headPos = boneData['posHAS']
+        headPos = boneData['posHAS']
+        tailVector = 0
+        if len(children) > 0:
+            for child in children:
+                tailVector = max(tailVector, bonesData[child]['position'][0])
+        if tailVector < MIN_BONE_LENGTH:
+            tailVector = averageBone
+
+        #boneObj.head = Vector([headPos[0], -headPos[2], headPos[1]])
+        #boneObj.tail = Vector([headPos[0], -headPos[2], headPos[1] + tailVector])
+
+        #print("bCreateSkeleton: bone=%s, boneObj.head=%s" % (bone, boneObj.head))
+        #print("bCreateSkeleton: bone=%s, boneObj.tail=%s" % (bone, boneObj.tail))
+        #boneObj.matrix =
+        rotmat = boneData['rotmatAS']
+        #print(rotmat[1].to_tuple())
+        #boneObj.matrix = Matrix(rotmat[1],rotmat[0],rotmat[2])
+        if blender_version <= 262:
+            r0 = [rotmat[0].x] + [rotmat[0].y] + [rotmat[0].z]
+            r1 = [rotmat[1].x] + [rotmat[1].y] + [rotmat[1].z]
+            r2 = [rotmat[2].x] + [rotmat[2].y] + [rotmat[2].z]
+            boneRotMatrix = Matrix((r1, r0, r2))
+        elif blender_version > 262:
+            # this is fugly way of flipping matrix
+            r0 = [rotmat.col[0].x] + [rotmat.col[0].y] + [rotmat.col[0].z]
+            r1 = [rotmat.col[1].x] + [rotmat.col[1].y] + [rotmat.col[1].z]
+            r2 = [rotmat.col[2].x] + [rotmat.col[2].y] + [rotmat.col[2].z]
+            tmpR = Matrix((r1, r0, r2))
+            boneRotMatrix = Matrix((tmpR.col[0], tmpR.col[1], tmpR.col[2]))
+
+        #pos = Vector([headPos[0],-headPos[2],headPos[1]])
+        #axis, roll = mat3_to_vec_roll(boneRotMatrix.to_3x3())
+
+        #boneObj.head = pos
+        #boneObj.tail = pos + axis
+        #boneObj.roll = roll
+
+        #print("bCreateSkeleton: bone=%s, newrotmat=%s" % (bone, Matrix((r1,r0,r2))))
+        #print(r1)
+        #mtx = Matrix.to_3x3()Translation(boneObj.head) # Matrix((r1,r0,r2))
+        #boneObj.transform(Matrix((r1,r0,r2)))
+        #print("bCreateSkeleton: bone=%s, matrix_before=%s" % (bone, boneObj.matrix))
+        #boneObj.use_local_location = False
+        #boneObj.transform(Matrix((r1,r0,r2)) , False, False)
+        #print("bCreateSkeleton: bone=%s, matrix_after=%s" % (bone, boneObj.matrix))
+        boneObj.head = Vector([0, 0, 0])
+        #boneObj.tail = Vector([0,0,tailVector])
+        boneObj.tail = Vector([0, tailVector, 0])
+        #matx = Matrix.Translation(Vector([headPos[0],-headPos[2],headPos[1]]))
+
+        boneObj.transform(boneRotMatrix)
+        #scn.update()
+        boneObj.translate(Vector([headPos[0], -headPos[2], headPos[1]]))
+        #scn.update()
+        #boneObj.translate(Vector([headPos[0],-headPos[2],headPos[1]]))
+        #boneObj.head = Vector([headPos[0],-headPos[2],headPos[1]])
+        #boneObj.tail = Vector([headPos[0],-headPos[2],headPos[1]]) + (Vector([0,0, tailVector])  * Matrix((r1,r0,r2)))
+
+        #amt.bones[bone] = boneObj
+        #amt.update_tag(refresh)
+
+    # Only after all bones are created we can link parents
+    for bone in bonesData.keys():
+        boneData = bonesData[bone]
+        parent = None
+        if 'parent' in boneData.keys():
+            parent = boneData['parent']
+            # get bone obj
+            boneData = bonesData[bone]
+            boneName = boneData['name']
+            boneObj = amt.edit_bones[boneName]
+            boneObj.parent = amt.edit_bones[parent]
+
+    # Need to refresh armature before removing bones
+    bpy.ops.object.mode_set(mode='OBJECT')
+    bpy.ops.object.mode_set(mode='EDIT')
+
+    # Delete helper/zero bones
+    for bone in amt.bones.keys():
+        # print("keys of bone=%s" % bonesData[bone].keys())
+        if 'flag' in bonesData[bone].keys():
+            # print ("deleting bone=%s" % bone)
+            bpy.context.object.data.edit_bones.remove(amt.edit_bones[bone])
+
+    bpy.ops.object.mode_set(mode='OBJECT')
+    #for (bname, pname, vector) in boneTable:
+    #    bone = amt.edit_bones.new(bname)
+    #    if pname:
+    #        parent = amt.edit_bones[pname]
+    #        bone.parent = parent
+    #        bone.head = parent.tail
+    #        bone.use_connect = False
+    #        (trans, rot, scale) = parent.matrix.decompose()
+    #    else:
+    #        bone.head = (0,0,0)
+    #        rot = Matrix.Translation((0,0,0))    # identity matrix
+    #    bone.tail = rot * Vector(vector) + bone.head
+    #bpy.ops.object.mode_set(mode='OBJECT')
+
+def bMergeVertices(subMesh):
+    # This sort of works, but leaves all uv seams as sharp.
+    geometry = subMesh['geometry']
+    vertices = geometry['positions']
+    normals = geometry['normals']
+    uvsets = geometry['uvsets'] if 'uvsets' in geometry else None
+    lookup = {}
+    map = [i for i in range(len(vertices))]
+    for i in range(len(vertices)):
+        vert = vertices[i]
+        norm = normals[i]
+        uv = tuple(uvsets[i][0]) if uvsets else None
+        item = (tuple(vert), tuple(norm), uv)
+        target = lookup.get(item)
+        if target is None:
+            lookup[item] = i
+        else:
+            map[i] = target
+    # update faces
+    faces = subMesh['faces']
+    for face in faces:
+        for i in range(len(face)):
+            face[i] = map[face[i]]
+
+
+def bCreateSubMeshes(meshData, meshName):
+    allObjects = []
+    submeshes = meshData['submeshes']
+
+    for subMeshIndex in range(len(submeshes)):
+        subMeshData = submeshes[subMeshIndex]
+        subMeshName = subMeshData['material']
+        Report.meshes.append( subMeshName )
+        
+        # Create mesh and object
+        me = bpy.data.meshes.new(subMeshName)
+        ob = bpy.data.objects.new(subMeshName, me)
+
+        # Link object to scene
+        scn = bpy.context.scene
+        scn.objects.link(ob)
+        scn.objects.active = ob
+        scn.update()
+
+        # Check for submesh geometry, or take the shared one
+        if 'geometry' in subMeshData.keys():
+            geometry = subMeshData['geometry']
+        else:
+            geometry = meshData['sharedgeometry']
+
+        verts = geometry['positions']
+        faces = subMeshData['faces']
+        
+        hasNormals = False
+        if 'normals' in geometry.keys():
+            normals = geometry['normals']
+            hasNormals = True
+        # Mesh vertices and faces
+
+        if(blender_version <= 262):
+            # Vertices and faces of mesh
+            me.from_pydata(verts, [], faces)
+            # Mesh normals
+            c = 0
+            for v in me.vertices:
+                if hasNormals:
+                    v.normal = Vector((normals[c][0], normals[c][1], normals[c][2]))
+                    c += 1
+        elif(blender_version > 262):
+            # Vertices and faces of mesh
+            VertLength = len(verts)
+            FaceLength = len(faces)
+            me.vertices.add(VertLength)
+            me.tessfaces.add(FaceLength)
+            for i in range(VertLength):
+                me.vertices[i].co = verts[i]
+                if hasNormals:
+                    me.vertices[i].normal = Vector((normals[i][0], normals[i][1], normals[i][2]))
+            #me.vertices[VertLength].co = verts[0]
+            for i in range(FaceLength):
+                NewFace = (faces[i][0], faces[i][1], faces[i][2], 0)
+                me.tessfaces[i].vertices_raw = NewFace
+
+        # Blender 2.62 <-> 2.63 compatibility
+        if(blender_version <= 262):
+            meshFaces = me.faces
+            meshUV_textures = me.uv_textures
+            meshVertex_colors = me.vertex_colors
+        elif(blender_version > 262):
+            meshFaces = me.tessfaces
+            meshUV_textures = me.tessface_uv_textures
+            meshVertex_colors = me.tessface_vertex_colors
+            #meshUV_textures = me.uv_textures
+
+        # Smooth
+        for f in meshFaces:
+            f.use_smooth = True
+
+        hasTexture = False
+        # Material for the submesh
+        # Create image texture from image.
+        if subMeshName in meshData['materials']:
+            matInfo = meshData['materials'][subMeshName]  # material data
+            Report.materials.append( subMeshName )
+            
+            if 'texture' in matInfo:
+                texturePath = matInfo['texture']
+                if texturePath:
+                    hasTexture = True
+                    Report.textures.append( matInfo['imageNameOnly'] )
+                    
+                    # Try to find among already loaded images
+                    tex = None
+                    for lTex in bpy.data.textures:
+                        if lTex.type == 'IMAGE':
+                            if lTex.image.name == matInfo['imageNameOnly']:
+                                tex = lTex
+                                break
+                    if not tex:
+                        tex = bpy.data.textures.new(matInfo['imageNameOnly'], type='IMAGE')
+                        tex.image = bpy.data.images.load(texturePath)
+                        tex.use_alpha = True
+
+            # Create shadeless material and MTex
+            mat = bpy.data.materials.new(subMeshName)
+            # Ambient
+            if 'ambient' in matInfo:
+                #mat.ambient = matInfo['ambient'][0]
+                # RGB to Grayscale Weighted method or luminosity method: ( (0.3 * R) + (0.59 * G) + (0.11 * B) )
+                if len(matInfo['ambient']) == 3:
+                    mat.ambient = (matInfo['ambient'][0] * 0.2126 + matInfo['ambient'][1] * 0.7152 + matInfo['ambient'][2] * 0.0722);
+                else:
+                    mat.ambient = (matInfo['ambient'][0] * 0.2126 + matInfo['ambient'][1] * 0.7152 + matInfo['ambient'][2] * 0.0722) * matInfo['ambient'][3];
+            else:
+                mat.ambient = 1.0
+
+            # Diffuse
+            if 'diffuse' in matInfo:
+                mat.diffuse_color = matInfo['diffuse'][0:3]
+            else:
+                mat.diffuse_color = [1.0, 1.0, 1.0]
+
+            # Specular
+            if 'specular' in matInfo:
+                mat.specular_color = matInfo['specular'][0:3]
+                
+                # RGB to Grayscale Weighted method or luminosity method: ( (0.3 * R) + (0.59 * G) + (0.11 * B) )
+                mat.specular_intensity = (matInfo['specular'][0] * 0.2126 + matInfo['specular'][1] * 0.7152 + matInfo['specular'][2] * 0.0722);
+
+                if len(matInfo['specular']) == 4:
+                    if matInfo['specular'][3] <= 1:
+                        mat.specular_intensity = (matInfo['specular'][0] * 0.2126 + matInfo['specular'][1] * 0.7152 + matInfo['specular'][2] * 0.0722) * matInfo['specular'][3];
+                    else:
+                        mat.specular_hardness = matInfo['specular'][3] * 4
+
+                elif len(matInfo['specular']) == 5:
+                    mat.specular_hardness = matInfo['specular'][4] * 4
+                    
+            else:
+                mat.specular_color = [0.0, 0.0, 0.0]
+
+            # Emmisive
+            if 'emissive' in matInfo:
+                mat.emit = matInfo['emissive'][0]
+                #mat.emit = matInfo['emissive'][0]
+                # RGB to Grayscale Weighted method or luminosity method: ( (0.3 * R) + (0.59 * G) + (0.11 * B) )
+                if len(matInfo['emissive']) == 3:
+                    mat.emit = (matInfo['emissive'][0] * 0.2126 + matInfo['emissive'][1] * 0.7152 + matInfo['emissive'][2] * 0.0722);
+                else:
+                    mat.emit = (matInfo['emissive'][0] * 0.2126 + matInfo['emissive'][1] * 0.7152 + matInfo['emissive'][2] * 0.0722) * matInfo['emissive'][3];
+            else:
+                mat.emit = 0.0
+
+            #mat.use_shadeless = True
+            
+            if 'vertexcolour' in matInfo:
+                mat.use_vertex_color_paint = True
+            
+            if 'depth_bias' in matInfo:
+                mat.offset_z = matInfo['depth_bias']
+            
+            if 'receive_shadows' in matInfo:
+                mat.use_shadows = matInfo['receive_shadows']
+
+            mtex = mat.texture_slots.add()
+            if hasTexture:
+                mtex.texture = tex
+            mtex.texture_coords = 'UV'
+            mtex.use_map_color_diffuse = True
+
+            # Add material to object
+            ob.data.materials.append(mat)
+            # logger.debug(me.uv_textures[0].data.values()[0].image)
+        else:
+            logger.warning("Definition of material: %s not found!" % subMeshName)
+            Report.warnings.append("Definition of material: %s not found!" % subMeshName)
+
+        # Texture coordinates
+        if 'texcoordsets' in geometry and 'uvsets' in geometry:
+            uvsets = geometry['uvsets']
+            for j in range(geometry['texcoordsets']):
+                uvLayer = meshUV_textures.new('UVLayer'+str(j))
+
+                meshUV_textures.active = uvLayer
+
+                for f in meshFaces:
+                    uvco1sets = uvsets[f.vertices[0]]
+                    uvco2sets = uvsets[f.vertices[1]]
+                    uvco3sets = uvsets[f.vertices[2]]
+                    uvco1 = Vector((uvco1sets[j][0], uvco1sets[j][1]))
+                    uvco2 = Vector((uvco2sets[j][0], uvco2sets[j][1]))
+                    uvco3 = Vector((uvco3sets[j][0], uvco3sets[j][1]))
+                    uvLayer.data[f.index].uv = (uvco1, uvco2, uvco3)
+                    if hasTexture:
+                        # This will link image to faces
+                        uvLayer.data[f.index].image = tex.image
+                        # uvLayer.data[f.index].use_image=True
+
+        # Vertex colors
+        if 'vertexcolors' in geometry:
+            colorLayer = meshVertex_colors.new('Colour')
+            meshVertex_colors.active = colorLayer
+            vcolors = geometry['vertexcolors']
+            for f in meshFaces:
+                colv1 = vcolors[f.vertices[0]]
+                colv2 = vcolors[f.vertices[1]]
+                colv3 = vcolors[f.vertices[2]]
+                colorLayer.data[f.index].color1 = (colv1[0], colv1[1], colv1[2])
+                colorLayer.data[f.index].color2 = (colv2[0], colv2[1], colv2[2])
+                colorLayer.data[f.index].color3 = (colv3[0], colv3[1], colv3[2])
+            
+            # Vertex Alpha
+            for c in vcolors:
+                if c[3] != 1.0:
+                    alphaLayer = meshVertex_colors.new('Alpha')
+                    for f in meshFaces:
+                        a1 = vcolors[f.vertices[0]][3]
+                        a2 = vcolors[f.vertices[1]][3]
+                        a3 = vcolors[f.vertices[2]][3]
+                        alphaLayer.data[f.index].color1 = (a1, a1, a1)
+                        alphaLayer.data[f.index].color2 = (a2, a2, a2)
+                        alphaLayer.data[f.index].color3 = (a3, a3, a3)
+                    break
+
+        # Bone assignments:
+        if 'boneIDs' in meshData:
+            if 'boneassignments' in geometry.keys():
+                vgroups = geometry['boneassignments']
+                for vgname, vgroup in vgroups.items():
+                    # logger.debug("creating VGroup %s" % vgname)
+                    grp = ob.vertex_groups.new(vgname)
+                    for (v, w) in vgroup:
+                        #grp.add([v], w, 'REPLACE')
+                        grp.add([v], w, 'ADD')
+                        
+        # Give mesh object an armature modifier, using vertex groups but not envelopes
+        if 'skeleton' in meshData:
+            skeletonName = meshData['skeletonName']
+            Report.armatures.append(skeletonName)
+            
+            mod = ob.modifiers.new('OgreSkeleton', 'ARMATURE')
+            mod.object = bpy.data.objects[skeletonName]  # gets the rig object
+            mod.use_bone_envelopes = False
+            mod.use_vertex_groups = True
+
+        elif 'armature' in meshData:
+            mod = ob.modifiers.new('OgreSkeleton', 'ARMATURE')
+            mod.object = meshData['armature']
+            mod.use_bone_envelopes = False
+            mod.use_vertex_groups = True
+
+        # Shape keys (poses)
+        if 'poses' in meshData:
+            base = None
+            for pose in meshData['poses']:
+                if(pose['submesh'] == subMeshIndex):
+                    if base is None:
+                        # Must have base shape
+                        base = ob.shape_key_add('Basis')
+                    name = pose['name']
+                    Report.shape_animations.append(name)
+                    
+                    logger.info('* Creating pose', name)
+                    shape = ob.shape_key_add(name)
+                    for vkey in pose['data']:
+                        b = base.data[vkey[0]].co
+                        me.shape_keys.key_blocks[name].data[vkey[0]].co = [
+                            vkey[1] + b[0], vkey[2] + b[1], vkey[3] + b[2]]
+
+        # Update mesh with new data
+        me.update(calc_edges=True)
+        me.use_auto_smooth = True
+
+        Report.orig_vertices = len( me.vertices )
+
+        bpy.ops.object.editmode_toggle()
+        bpy.ops.mesh.remove_doubles(threshold=0.001)
+        bpy.ops.object.editmode_toggle()
+
+        # Update mesh with new data
+        me.update(calc_edges=True, calc_tessface=True)
+
+        Report.faces += len( me.tessfaces )
+        Report.triangles += len( me.tessfaces )
+        Report.vertices += len( me.vertices )
+
+        # Try to set custom normals
+        if hasNormals:
+            noChange = len(me.loops) == len(faces)*3
+            if not noChange:
+                logger.debug('Removed %s faces' % (len(faces) - len(me.loops) / 3))
+            split = []
+            polyIndex = 0
+            for face in faces:
+                if noChange or matchFace(face, verts, me, polyIndex):
+                    polyIndex += 1
+                    for vx in face:
+                        split.append(normals[vx])
+
+            if len(split) == len(me.loops):
+                me.normals_split_custom_set(split)
+            else:
+                Report.warnings.append("Failed to import mesh normals")
+                logger.warning('Failed to import mesh normals %s / %s', (polyIndex, len(me.polygons)))
+
+        allObjects.append(ob)
+
+    # Forced view mode with textures
+    #if TEXTURE_VIEW_MODE:
+    #    bpy.context.scene.game_settings.material_mode = 'GLSL'
+    #    areas = bpy.context.screen.areas
+    #    for area in areas:
+    #        if area.type == 'VIEW_3D':
+    #            area.spaces.active.viewport_shade = 'TEXTURED'
+
+    return allObjects
+
+
+def matchFace(face, vertices, mesh, index):
+    if index >= len(mesh.polygons):
+        return False  # ?? err - what broke
+    loop = mesh.polygons[index].loop_start
+    for v in face:
+        vi = mesh.loops[loop].vertex_index
+        vx = mesh.vertices[vi].co
+
+        if (vx-Vector(vertices[v])).length_squared > 1e-6:
+            return False
+
+        # if vx != Vector(vertices[v]):
+        #    return False  # May need threshold ?
+        loop += 1
+    return True
+
+
+def getBoneNameMapFromArmature(arm):
+        # Get Ogre bone IDs - need to be in edit mode to access edit_bones
+        # Arm should already be the active object
+        boneMap = {}
+        bpy.context.scene.objects.active = arm
+        bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+        bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+        for bone in arm.data.edit_bones:
+            if 'OGREID' in bone:
+                boneMap[ str(bone['OGREID']) ] = bone.name;
+        bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+        return boneMap
+
+def load(filepath):
+    global blender_version
+
+    blender_version = bpy.app.version[0] * 100 + bpy.app.version[1]
+
+    logger.info("* Loading mesh from: %s" % str(filepath))
+
+    filepath = filepath
+    pathMeshXml = filepath
+    # Get the mesh as .xml file
+    if filepath.lower().endswith(".mesh"):
+        if mesh_convert(filepath):
+            pathMeshXml = filepath + ".xml"
+        else:
+            logger.error("Failed to convert .mesh file %s to .xml" % filepath)
+            Report.errors.append("Failed to convert .mesh file to .xml")
+            return {'CANCELLED'}
+    elif filepath.lower().endswith(".xml"):
+        pathMeshXml = filepath
+    else:
+        return {'CANCELLED'}
+
+    folder = os.path.split(filepath)[0]
+    nameDotMeshDotXml = os.path.split(pathMeshXml)[1]
+    nameDotMesh = os.path.splitext(nameDotMeshDotXml)[0]
+    onlyName = os.path.splitext(nameDotMesh)[0]
+
+    # Material
+    meshMaterials = []
+    nameDotMaterial = onlyName + ".material"
+    pathMaterial = os.path.join(folder, nameDotMaterial)
+    if not os.path.isfile(pathMaterial):
+        # Search directory for .material
+        for filename in os.listdir(folder):
+            if ".material" in filename:
+                # Material file
+                pathMaterial = os.path.join(folder, filename)
+                meshMaterials.append(pathMaterial)
+                # logger.info("alternative material file: %s" % pathMaterial)
+    else:
+        meshMaterials.append(pathMaterial)
+
+    # Try to parse xml file
+    xDocMeshData = xOpenFile(pathMeshXml)
+
+    meshData = {}
+    if xDocMeshData != "None":
+        # Skeleton data
+        # Get the mesh as .xml file
+        skeletonFile = xGetSkeletonLink(xDocMeshData, folder)
+
+        # Use selected skeleton
+        selectedSkeleton = context.active_object \
+            if (config.get('USE_SELECTED_SKELETON')
+                and context.active_object
+                and context.active_object.type == 'ARMATURE') else None
+        if selectedSkeleton:
+            map = getBoneNameMapFromArmature(selectedSkeleton)
+            if map:
+                meshData['boneIDs'] = map
+                meshData['armature'] = selectedSkeleton
+            else:
+                Report.warnings.append("Selected armature has no OGRE data.")
+        
+        # There is valid skeleton link and existing file
+        elif skeletonFile != "None":
+            if mesh_convert(skeletonFile):
+                skeletonFileXml = skeletonFile + ".xml"
+
+                # Parse .xml skeleton file
+                xDocSkeletonData = xOpenFile(skeletonFileXml)
+                if xDocSkeletonData != "None":
+                    xCollectBoneData(meshData, xDocSkeletonData)
+                    meshData['skeletonName'] = os.path.basename(skeletonFile[:-9])
+
+                    # Parse animations
+                    if config.get('IMPORT_ANIMATIONS'):
+                        fps = xAnalyseFPS(xDocSkeletonData)
+                        if(fps and config.get('ROUND_FRAMES')):
+                            logger.info("Setting FPS to", fps)
+                            bpy.context.scene.render.fps = fps
+                        xCollectAnimations(meshData, xDocSkeletonData)
+
+            else:
+                Report.warnings.append("Failed to load linked skeleton")
+                logger.warning("Failed to load linked skeleton")
+
+        # Collect mesh data
+        xCollectMeshData(meshData, xDocMeshData, onlyName, folder)
+        MaterialParser.xCollectMaterialData(meshData, onlyName, folder)
+        
+        if config.get('IMPORT_SHAPEKEYS'):
+            xCollectPoseData(meshData, xDocMeshData)
+
+        # After collecting is done, start creating stuff#
+        # Create skeleton (if any) and mesh from parsed data
+        bCreateMesh(meshData, folder, onlyName, pathMeshXml)
+        bCreateAnimations(meshData)
+        if config.get('XML_DELETE'):
+            # Cleanup by deleting the XML file we created
+            os.unlink("%s" % pathMeshXml)
+            if 'skeleton' in meshData:
+                os.unlink("%s" % skeletonFileXml)
+
+    return {'FINISHED'}

--- a/io_ogre/report.py
+++ b/io_ogre/report.py
@@ -26,6 +26,7 @@ class ReportSingleton(object):
         self.errors = []
         self.messages = []
         self.paths = []
+        self.importing = False
 
     def report(self):
         r = ['Report:']
@@ -48,11 +49,16 @@ class ReportSingleton(object):
             for a in self.paths: r.append( '    - %s' %a )
 
         if self.vertices:
-            r.append( '  Original Vertices: %s' %self.orig_vertices)
-            r.append( '  Exported Vertices: %s' %self.vertices )
-            r.append( '  Original Faces: %s' %self.faces )
-            r.append( '  Exported Triangles: %s' %self.triangles )
-            ## TODO report file sizes, meshes and textures
+            action_name = "Exported"
+            if self.importing:
+                action_name = "Imported"
+
+            r.append( '  Original Vertices: %s' % self.orig_vertices )
+            r.append( '  %s Vertices: %s' % (action_name, self.vertices) )
+            r.append( '  Original Faces: %s' % self.faces )
+            r.append( '  %s Triangles: %s' % (action_name, self.triangles) )
+        
+        ## TODO report file sizes, meshes and textures
 
         for tag in 'meshes lights cameras armatures armature_animations shape_animations materials textures'.split():
             attr = getattr(self, tag)

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -6,22 +6,25 @@ if "bpy" in locals():
     import importlib
     if "config" in locals():
         importlib.reload(config)
-    if "report.Report" in locals():
-        importlib.reload(report.Report)
+    if "report" in locals():
+        importlib.reload(report)
     if "material" in locals():
         importlib.reload(material)
+    if "importer" in locals():
+        importlib.reload(importer)
     if "export" in locals():
         importlib.reload(export)
     if "helper" in locals():
         importlib.reload(helper)
-    if "meshy.OGREMESH_OT_preview" in locals():
-        importlib.reload(meshy.OGREMESH_OT_preview)
+    if "meshy" in locals():
+        importlib.reload(meshy)
 
 # This is only relevant on first run, on later reloads those modules
 # are already in locals() and those statements do not do anything.
 from .. import config
 from ..report import Report
 from . import material
+from . import importer
 from . import export
 from . import helper
 from ..meshy import OGREMESH_OT_preview
@@ -32,6 +35,7 @@ def auto_register(register):
     yield MT_mini_report
     yield OGREMESH_OT_preview
 
+    yield from importer.auto_register(register)
     yield from export.auto_register(register)
     yield from helper.auto_register(register)
 

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -16,6 +16,8 @@ if "bpy" in locals():
         importlib.reload(scene)
     if "material" in locals():
         importlib.reload(material)
+    if "report" in locals():
+        importlib.reload(report)
 
 # This is only relevant on first run, on later reloads those modules
 # are already in locals() and those statements do not do anything.
@@ -90,7 +92,7 @@ class _OgreCommonExport_(object):
         
         # Options associated with each section
         section_options = {
-            "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_EXPORT_VERSION", "EX_XML_DELETE"], 
+            "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_VERSION", "EX_XML_DELETE"], 
             "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_EXPORT_USER", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"], 
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS"], 
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"], 
@@ -98,7 +100,7 @@ class _OgreCommonExport_(object):
             "Mesh" : ["EX_MESH", "EX_MESH_OVERWRITE", "EX_V1_EXTREMITY_POINTS", "EX_Vx_GENERATE_EDGE_LISTS", "EX_GENERATE_TANGENTS", "EX_Vx_OPTIMISE_ANIMATIONS", "EX_V2_OPTIMISE_VERTEX_BUFFERS", "OPTIMISE_VERTEX_BUFFERS_OPTIONS"], 
             "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT", "EX_LOD_MESH_TOOLS"], 
             "Shape Animation" : ["EX_SHAPE_ANIMATIONS", "EX_SHAPE_NORMALS"], 
-            "Logging" : ["EX_Vx_EXPORT_ENABLE_LOGGING"]
+            "Logging" : ["EX_Vx_ENABLE_LOGGING"]
         }
         
         for section in sections:
@@ -172,7 +174,7 @@ class _OgreCommonExport_(object):
         file_handler = None
         
         # Add a file handler to all Logger instances
-        if config.get('EXPORT_ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') == True:
             log_file = ("%s/blender2ogre.log" % target_path)
             logger.info("Writing log file to: %s" % log_file)
 
@@ -199,7 +201,7 @@ class _OgreCommonExport_(object):
         Report.show()
 
         # Flush and close all logging file handlers
-        if config.get('EXPORT_ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') == True:
             for logger_name in logging.Logger.manager.loggerDict.keys():
                 logger_instance = logging.getLogger(logger_name)
                     
@@ -230,11 +232,11 @@ class _OgreCommonExport_(object):
         name='Swap Axis',
         description='Axis swapping mode',
         default=config.get('SWAP_AXIS'))
-    EX_V2_MESH_TOOL_EXPORT_VERSION = EnumProperty(
-        items=config.MESH_EXPORT_VERSIONS,
+    EX_V2_MESH_TOOL_VERSION = EnumProperty(
+        items=config.MESH_TOOL_VERSIONS,
         name='Mesh Export Version',
         description='Specify Ogre version format to write',
-        default=config.get('MESH_TOOL_EXPORT_VERSION'))
+        default=config.get('MESH_TOOL_VERSION'))
     EX_XML_DELETE = BoolProperty(
         name="Clean up xml files",
         description="Remove the generated xml files after binary conversion. \n(The removal will only happen if OgreXMLConverter/OgreMeshTool finish successfully)",
@@ -410,10 +412,10 @@ Blenders decimate does LOD by collapsing vertices, which can result in a visuall
         default=config.get('SHAPE_NORMALS'))
     
     # Logging
-    EX_Vx_EXPORT_ENABLE_LOGGING = BoolProperty(
+    EX_Vx_ENABLE_LOGGING = BoolProperty(
         name="Write Exporter Logs",
         description="Write Log file to the output directory (blender2ogre.log)",
-        default=config.get('EXPORT_ENABLE_LOGGING'))
+        default=config.get('ENABLE_LOGGING'))
     
     # It seems that it is not possible to exclude DEBUG when selecting a log level
     #EX_Vx_DEBUG_LOGGING = BoolProperty(

--- a/io_ogre/ui/importer.py
+++ b/io_ogre/ui/importer.py
@@ -1,0 +1,276 @@
+import bpy, os, getpass, math, mathutils, logging
+
+from pprint import pprint
+
+# When bpy is already in local, we know this is not the initial import...
+if "bpy" in locals():
+    # ...so we need to reload our submodule(s) using importlib
+    import importlib
+    if "config" in locals():
+        importlib.reload(config)
+    if "ogre_import" in locals():
+        importlib.reload(ogre_import)
+    if "util" in locals():
+        importlib.reload(util)
+
+# This is only relevant on first run, on later reloads those modules
+# are already in locals() and those statements do not do anything.
+from bpy.props import EnumProperty, BoolProperty, FloatProperty, StringProperty, IntProperty
+from .. import config
+from ..ogre import ogre_import
+from ..report import Report
+from ..util import *
+from ..xml import *
+
+logger = logging.getLogger('import')
+
+def auto_register(register):
+    yield OP_ogre_import
+
+    if register:
+        bpy.types.INFO_MT_file_import.append(menu_func)
+    else:
+        bpy.types.INFO_MT_file_import.remove(menu_func)
+
+def menu_func(self, context):
+    """ invoked when import in drop down menu is clicked """
+    op = self.layout.operator(OP_ogre_import.bl_idname, text="Ogre3D (.mesh)")
+    return op
+
+class _OgreCommonImport_(object):
+
+    last_import_path = None
+
+    @classmethod
+    def poll(cls, context):
+        if context.mode != 'EDIT_MESH':
+            return True
+
+    def __init__(self):
+        # Check that converter is setup
+        self.converter = detect_converter_type()
+
+    def invoke(self, context, event):
+        # Update the interface with the config values
+        for key, value in config.CONFIG.items():
+            if getattr(self, "IM_" + key, None) or getattr(self, "IM_Vx_" + key, None) or getattr(self, "IM_V1_" + key, None) or getattr(self, "IM_V2_" + key, None):
+                # todo: isn't the key missing the "IM_" prefix?
+                setattr(self,key,value)
+
+        wm = context.window_manager
+        fs = wm.fileselect_add(self)
+        
+        return {'RUNNING_MODAL'}
+
+    def draw(self, context):
+        layout = self.layout
+
+        if self.converter == "unknown":
+            layout.label(text="No converter found! Please check your preferences.", icon='ERROR')
+        else:
+            layout.label(text="Using '%s'" % self.converter, icon='INFO')
+
+        # The Sections are listed in an array to have them in this particular order
+        sections = ["General", "Armature", "Mesh", "Shape Keys", "Logging"]
+        
+        # Icons to use for the sections
+        section_icons = {
+            "General" : "WORLD", "Armature" : "ARMATURE_DATA", "Mesh" : "MESH_DATA", "Shape Keys" : "POSE_DATA", "Logging" : "TEXT"
+        }
+        
+        # Options associated with each section
+        section_options = {
+            "General" : ["IM_SWAP_AXIS", "IM_V2_MESH_TOOL_VERSION", "IM_XML_DELETE"], 
+            "Armature" : ["IM_IMPORT_ANIMATIONS", "IM_ROUND_FRAMES", "IM_USE_SELECTED_SKELETON"], 
+            "Mesh" : ["IM_IMPORT_NORMALS", "IM_MERGE_SUBMESHES"], 
+            "Shape Keys" : ["IM_IMPORT_SHAPEKEYS"], 
+            "Logging" : ["IM_Vx_ENABLE_LOGGING"]
+        }
+        
+        for section in sections:
+            row = layout.row()
+            box = row.box()
+            box.label(text=section, icon=section_icons[section])
+            for prop in section_options[section]:
+                if prop.startswith('IM_V1_'):
+                    if self.converter == "OgreXMLConverter":
+                        box.prop(self, prop)
+                elif prop.startswith('IM_V2_'):
+                    if self.converter == "OgreMeshTool":
+                        box.prop(self, prop)
+                elif prop.startswith('IM_Vx_'):
+                    if self.converter != "unknown":
+                        box.prop(self, prop)
+                elif prop.startswith('IM_'):
+                    box.prop(self, prop)
+        
+    def execute(self, context):
+        # Add warinng about missing XML converter
+        Report.reset()
+        if self.converter == "unknown":
+            Report.errors.append(
+              "Cannot find suitable OgreXMLConverter or OgreMeshTool executable." +
+              "Import XML mesh - does NOT automatically convert .mesh to .xml file. You MUST run converter on the mesh manually.")
+
+        logger.debug("Context.blend_data: %s" % context.blend_data.filepath)
+        logger.debug("Context.scene.name: %s" % context.scene.name)
+        logger.debug("Self.filepath: %s" % self.filepath)
+        logger.debug("Self.last_import_path: %s" % self.last_import_path)
+
+        # Load addonPreference in CONFIG
+        config.update_from_addon_preference(context)
+
+        # Resolve path from opened .blend if available. 
+        # Normally it's not if blender was opened with "Recover Last Session".
+        # After import is done once, remember that path when re-importing.
+        if not self.last_import_path:
+            # First import during this blender run
+            if context.blend_data.filepath != "":
+                path, name = os.path.split(context.blend_data.filepath)
+                self.last_import_path = os.path.join(path, name.split('.')[0])
+
+        if not self.last_import_path:
+            self.last_import_path = os.path.expanduser("~")
+
+        if self.filepath == "" or not self.filepath:
+            self.filepath = "blender2ogre"
+
+        logger.debug("Self.filepath: %s" % self.filepath)
+
+        kw = {}
+        for name in dir(_OgreCommonImport_):
+            if name.startswith('IM_V1_'):
+                kw[ name[6:] ] = getattr(self,name)
+            elif name.startswith('IM_V2_'):
+                kw[ name[6:] ] = getattr(self,name)
+            elif name.startswith('IM_Vx_'):
+                kw[ name[6:] ] = getattr(self,name)
+            elif name.startswith('IM_'):
+                kw[ name[3:] ] = getattr(self,name)
+        config.update(**kw)
+
+        print ("_" * 80)
+        
+        target_path, target_file_name = os.path.split(os.path.abspath(self.filepath))
+        target_file_name = clean_object_name(target_file_name)
+        target_file_name_no_ext = os.path.splitext(target_file_name)[0]
+
+        file_handler = None
+        
+        # Add a file handler to all Logger instances
+        if config.get('ENABLE_LOGGING') == True:
+            log_file = ("%s/blender2ogre.log" % target_path)
+            logger.info("Writing log file to: %s" % log_file)
+
+            file_handler = logging.FileHandler(filename=log_file, mode='w', encoding='utf-8', delay=False)
+            
+            # Show the python file name from where each log message originated
+            SHOW_LOG_NAME = False
+            
+            if SHOW_LOG_NAME:
+                file_formatter = logging.Formatter(fmt='%(asctime)s %(name)9s.py [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+            else:
+                file_formatter = logging.Formatter(fmt='%(asctime)s [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+
+            file_handler.setFormatter(file_formatter)
+
+            for logger_name in logging.Logger.manager.loggerDict.keys():
+                logging.getLogger(logger_name).addHandler(file_handler)
+
+        logger.info("Target_path: %s" % target_path)
+        logger.info("Target_file_name: %s" % target_file_name)
+
+        Report.importing = True
+        ogre_import.load(os.path.join(target_path, target_file_name))
+        Report.show()
+
+        # Flush and close all logging file handlers
+        if config.get('ENABLE_LOGGING') == True:
+            for logger_name in logging.Logger.manager.loggerDict.keys():
+                logger_instance = logging.getLogger(logger_name)
+                    
+                # Remove handlers
+                logger_instance.handlers.clear()
+            
+            file_handler.flush()
+            file_handler.close()
+
+        return {'FINISHED'}
+
+    filepath = StringProperty(name="File Path",
+        description="Filepath used for importing Ogre .mesh file",
+        maxlen=1024,
+        default="",
+        subtype='FILE_PATH')
+
+    # Basic options
+    # NOTE config values are automatically propagated if you name it like: IM_<config-name>
+    # Properties can also be enabled for a specific converter by adding V1 or V2 in the name:
+    # IM_V1_<config-name> for OgreXMLConverter
+    # IM_V2_<config-name> for OgreMeshTool
+    # IM_Vx_<config-name> for OgreXMLConverter and OgreMeshTool (hide only when no converter found)
+
+    # General
+    IM_SWAP_AXIS = EnumProperty(
+        items=config.AXIS_MODES,
+        name='Swap Axis',
+        description='Axis swapping mode',
+        default=config.get('SWAP_AXIS'))
+
+    IM_V2_MESH_TOOL_VERSION = EnumProperty(
+        items=config.MESH_TOOL_VERSIONS,
+        name='Mesh Import Version',
+        description='Specify Ogre version format to read',
+        default=config.get('MESH_TOOL_VERSION'))
+
+    IM_XML_DELETE = BoolProperty(
+        name="Clean up xml files",
+        description="Remove the generated xml files after binary conversion. \n(The removal will only happen if OgreXMLConverter/OgreMeshTool finish successfully)",
+        default=config.get('XML_DELETE'))
+
+    # Mesh
+    IM_IMPORT_NORMALS = BoolProperty(
+        name="Import Normals",
+        description="Import custom mesh normals",
+        default=config.get('IMPORT_NORMALS'))
+
+    IM_MERGE_SUBMESHES = BoolProperty(
+        name="Merge Submeshes",
+        description="Whether to merge submeshes to form a single mesh with different materials",
+        default=config.get('MERGE_SUBMESHES'))
+
+    # Armature
+    IM_IMPORT_ANIMATIONS = BoolProperty(
+        name="Import animation",
+        description="Import animations as actions",
+        default=config.get('IMPORT_ANIMATIONS'))
+
+    IM_ROUND_FRAMES = BoolProperty(
+        name="Adjust frame rate",
+        description="Adjust scene frame rate to match imported animation",
+        default=config.get('ROUND_FRAMES'))
+
+    IM_USE_SELECTED_SKELETON = BoolProperty(
+        name='Use selected skeleton',
+        description='Link with selected armature object rather than importing a skeleton.\nUse this for importing skinned meshes that don\'t have their own skeleton.\nMake sure you have the correct skeleton selected or the weight maps may get mixed up.',
+        default=config.get('USE_SELECTED_SKELETON'))
+
+    # Shape Keys
+    IM_IMPORT_SHAPEKEYS = BoolProperty(
+        name="Import shape keys",
+        description="Import shape keys (morphs)",
+        default=config.get('IMPORT_SHAPEKEYS'))
+    
+    # Logging
+    IM_Vx_ENABLE_LOGGING = BoolProperty(
+        name="Write Importer Logs",
+        description="Write Log file to the output directory (blender2ogre.log)",
+        default=config.get('ENABLE_LOGGING'))
+
+
+class OP_ogre_import(bpy.types.Operator, _OgreCommonImport_):
+    '''Import Ogre Scene'''
+    bl_idname = "ogre.import_mesh"
+    bl_label = "Import Ogre"
+    bl_options = {'REGISTER'}
+    # import logic is contained in the subclass


### PR DESCRIPTION
Modifications done to the importer:
 - Be abple to open .xml files as well as .mesh
 - Option to be able to merge imported submeshes
 - New material parser that uses a port of the Ogre tokenizer in order to better parse material files. (now it succesfully parsers Examples.material)
 - Added some more material properties to the parsing (adding features from blender2ogre's material.py and OgreMaterialSerializer.py)
 - Modified all logging and reporting to integrate into blender2ogre infrastructure
 - Modified all configuration options and paths to integrate into blender2ogre infrastructure
 - The former modification also allows the importer to generate log files

NOTE: Some option names throughout blender2ogre have changed to make them symmetric between import/export like `ENABLE_LOGGING` so users will have to delete their .pickle file when upgrading.

Tried importing every mesh in the samples and got the following results:

What works:
 - Meshes is what works best
 - Poses work OK, but tested on 'facial.mesh' only
 - Materials work so so because of the severe disparity between Blender and Ogre FFP
 - Skeletons work for the most part but the imported skeletons deviate from Blender standards, however the imported animations work OK
 - Animations work but depend on the skeleton which sometimes gets badly imported
