### PR TITLE
2.7x - Add instancing property to scene objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
  - [Importing meshes](#importing-meshes)
  - [Additional Features](#additional-features)
 	- [Merge Objects on export](#merge-objects-on-export)
+	- [Instancing and DotScene Plugin](#instancing-and-dotscene-plugin)
 	- [External OGRE Materials](#external-ogre-materials)
 	- [Console Export](#console-export)
 	- [Exporting Custom Vertex Groups](#exporting-custom-vertex-groups)
@@ -66,6 +67,13 @@ In order to have control over the precise location of where the merged objects o
 Setting any value other than the default `(0, 0, 0)` will result in a mesh with the origin set to that value. For example:
 
 ![dupli-offset.png](images/dupli-offset.png)
+
+### Instancing and DotScene Plugin
+As of OGRE 1.13 a new feature has been added to the DotScene Plugin where it now accepts the static / instanced keywords for entities.
+(for more information read the [DotScene Plugin README](https://github.com/sercero/ogre/blob/master/PlugIns/DotScene/README.md)).
+
+To use this feature create a new group (Ctrl+G) named as `static.<Group Name>` or `instanced.<Instance Manager Name>` and blender2ogre will automatically add the corresponding attribute to the exported entities in the Scene.
+This feature goes hand in hand with [Exporting Particle Systems](#exporting-particle-systems) to create vegetation, debris and other static objects in your scene.
 
 ### External OGRE Materials
 You might already have some materials in OGRE that you do not want to export.

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -120,9 +120,16 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
         logger.info('* Writing shared geometry')
 
+        # Print a warning if there are no UV Maps created for the object
+        # and the user requested to have tangents generated 
+        # (they won't be without a UV Map)
+        if int(config.get("GENERATE_TANGENTS")) != 0 and len(mesh.uv_layers) == 0:
+            logger.warning("No UV Maps were created for this object: <%s>, tangents won't be exported." % ob.name)
+            Report.warnings.append( 'Object "%s" has no UV Maps, tangents won\'t be exported.' % ob.name )
+        
         # Textures
         dotextures = False
-        if mesh.tessface_uv_textures.active:
+        if mesh.uv_layers:
             dotextures = True
         else:
             tangents = 0

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -140,8 +140,11 @@ def dot_scene(path, scene_name=None):
         group = get_merge_group( ob )
         if group:
             for member in group.objects:
-                if member not in mobjects: mobjects.append( member )
-            if group not in mgroups: mgroups.append( group )
+                if member not in mobjects:
+                    mobjects.append( member )
+            if group not in mgroups:
+                mgroups.append( group )
+
     for rem in mobjects:
         if rem in objects:
             objects.remove( rem )
@@ -297,6 +300,14 @@ def _property_helper(doc, user, propname, propvalue):
     prop.setAttribute('data', str(propvalue))
     prop.setAttribute('type', type(propvalue).__name__)
 
+def _mesh_instance_helper(e, ob, type):
+    group = get_merge_group( ob, type )
+    
+    # The 'static' / 'instanced' attribute indicates that the mesh will be instanced with either static geometry or instancing
+    # The static geometry / instancing manager name is given by the group: (static | instancing).MyGroup
+    if group != None:
+        e.setAttribute( type, group.name[len(type + "."):] )
+
 def _mesh_entity_helper(doc, ob, o):
     user = doc.createElement('userData')
     o.appendChild(user)
@@ -404,7 +415,7 @@ def ogre_document(materials):
     for mat in materials:
         item = doc.createElement('item')
         extern.appendChild( item )
-        item.setAttribute('type','material')
+        item.setAttribute('type', 'material')
         a = doc.createElement('file')
         item.appendChild( a )
         a.setAttribute('name', material.material_name(mat))
@@ -490,17 +501,14 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         if ob.data.name in mesh_collision_files:
             collisionFile = mesh_collision_files[ ob.data.name ]
         
-        # Print a warning if there are no UV Maps created for the object
-        # and the user requested to have tangents generated 
-        # (they won't be without a UV Map)
-        if int(config.get("GENERATE_TANGENTS")) != 0 and len(ob.data.uv_layers) == 0:
-            logger.warning("No UV Maps were created for this object: <%s>, tangents won't be exported." % ob.name)
-            Report.warnings.append( 'Object "%s" has no UV Maps, tangents won\'t be exported.' % ob.name )
-
         e = doc.createElement('entity')
         o.appendChild(e); e.setAttribute('name', ob.name)
         prefix = ''
         e.setAttribute('meshFile', '%s%s.mesh' % (prefix, clean_object_name(ob.data.name)) )
+        
+        # Set the instancing attribute if the object belongs to the correct group
+        _mesh_instance_helper(e, ob, "static")
+        _mesh_instance_helper(e, ob, "instanced")
 
         if not collisionPrim and not collisionFile:
             if ob.game.use_collision_bounds:
@@ -546,18 +554,25 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                     Report.warnings.append("Object \"%s\" has unsupported array-modifier mode, must be of 'Constant Offset' type" % ob.name)
                     continue
                 else:
-                    #v = ob.matrix_world.to_translation()
                     newvecs = []
                     for prev in vecs:
-                        for i in range( mod.count-1 ):
-                            v = prev + mod.constant_offset_displace
+                        for i in range( mod.count - 1 ):
+                            count = len(vecs + newvecs)
+                            
+                            v = prev + (i + 1) * mod.constant_offset_displace
+                            
                             newvecs.append( v )
-                            ao = _ogre_node_helper( doc, ob, prefix='_array_%s_'%len(vecs+newvecs), pos=v )
+                            ao = _ogre_node_helper( doc, ob, prefix='_array_%s_' % count, pos=v )
                             xmlparent.appendChild(ao)
 
                             e = doc.createElement('entity')
-                            ao.appendChild(e); e.setAttribute('name', ob.data.name)
+                            ao.appendChild(e)
+                            e.setAttribute('name', '_array_%s_%s' % (count, ob.data.name))
                             e.setAttribute('meshFile', '%s.mesh' % clean_object_name(ob.data.name))
+
+                            # Set the instancing attribute if the object belongs to the correct group
+                            _mesh_instance_helper(e, ob, "static")
+                            _mesh_instance_helper(e, ob, "instanced")
 
                             if collisionPrim: e.setAttribute('collisionPrim', collisionPrim )
                             elif collisionFile: e.setAttribute('collisionFile', collisionFile )
@@ -577,6 +592,11 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
                     e = doc.createElement('entity')
                     ao.appendChild(e); e.setAttribute('name', ('%s_particle_%s_%s' % (clean_object_name(ob.data.name), index, clean_object_name(dupob.data.name))))
                     e.setAttribute('meshFile', '%s.mesh' % clean_object_name(dupob.data.name))
+                    
+                    # Set the instancing attribute if the object belongs to the correct group
+                    _mesh_instance_helper(e, dupob, "static")
+                    _mesh_instance_helper(e, dupob, "instanced")
+                    
                     index += 1
             else:
                 logger.warn("<%s> Particle System %s is not supported for export (should be of type: 'Hair' and render_type: 'Object')" % (ob.name, partsys.name))
@@ -593,11 +613,11 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         if ob.data.type == "PERSP":
             fovY = 0.0
             if (sx*aspx > sy*aspy):
-                fovY = 2*math.atan(sy*aspy*16.0/(ob.data.lens*sx*aspx))
+                fovY = 2 * math.atan(sy * aspy * 16.0 / (ob.data.lens * sx * aspx))
             else:
-                fovY = 2*math.atan(16.0/ob.data.lens)
+                fovY = 2 * math.atan(16.0 / ob.data.lens)
             # fov in radians - like OgreMax - requested by cyrfer
-            fov = math.radians( fovY*180.0/math.pi )
+            fov = math.radians( fovY * 180.0 / math.pi )
             c.setAttribute('projectionType', "perspective")
             c.setAttribute('fov', '%6f' % fov)
         else: # ob.data.type == "ORTHO":

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -624,18 +624,19 @@ def merge( objects ):
     bpy.ops.object.join()
     return bpy.context.active_object
 
-def get_merge_group( ob, prefix='merge.' ):
+def get_merge_group( ob, prefix='merge' ):
     m = []
     for grp in ob.users_group:
-        if grp.name.lower().startswith(prefix): m.append( grp )
+        if grp.name.lower().startswith(prefix + "."):
+            m.append( grp )
     if len(m)==1:
         #if ob.data.users != 1:
-        #    logger.warn( 'An instance can not be in a merge group' )
+        #    logger.warn( 'An instance cannot be in a merge group' )
         #    return
         return m[0]
     elif m:
-        logger.warn('An object can not be in two merge groups at the same time: %s' % ob.name)
-        return
+        logger.warn('Object %s in two %s groups at the same time' % (ob.name, prefix))
+        return None
 
 def wordwrap( txt ):
     r = ['']


### PR DESCRIPTION
 - Made get_merge_group() more generic
 - Fix exporting problems with the array modifier
 - Add instancing support (static / instancing) to scene.py
 - BUG Fix: At some point the exporting of UV Maps was broken
 - Change location of tangent warning to mesh.py where it makes more sense
 - Changed README to document the use of the instancing property