### PR TITLE
Add instancing support to exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Setting any value other than the default `(0, 0, 0)` will result in a mesh with 
 
 ![dupli-offset.png](images/dupli-offset.png)
 
+### Instancing and DotScene Plugin
+As of OGRE 1.13 a new feature has been added to the DotScene Plugin where it now accepts the static / instanced keywords for entities.
+(for more information read the [DotScene Plugin README](https://github.com/sercero/ogre/blob/master/PlugIns/DotScene/README.md)).
+
+To use this feature create a new collection (M) names as `static.<Group Name>` or `instanced.<Instance Manager Name>` and blender2ogre will automatically add the corresponding attribute to the exported entities in the Scene.
+This feature goes hand in hand with [Exporting Particle Systems](#exporting-particle-systems) to create vegetation, debris and other static objects in your scene.
+
 ### External OGRE Materials
 You might already have some materials in OGRE that you do not want to export.
 Prefix them with `extern.<yourname>` and the sub entity will have the material name set, but the material is not exported. 

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -132,9 +132,16 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
 
         logger.info('* Writing shared geometry')
 
+        # Print a warning if there are no UV Maps created for the object
+        # and the user requested to have tangents generated 
+        # (they won't be without a UV Map)
+        if int(config.get("GENERATE_TANGENTS")) != 0 and len(mesh.uv_layers) == 0:
+            logger.warning("No UV Maps were created for this object: <%s>, tangents won't be exported." % ob.name)
+            Report.warnings.append( 'Object "%s" has no UV Maps, tangents won\'t be exported.' % ob.name )
+        
         # Textures
         dotextures = False
-        if mesh.uv_layers.active:
+        if mesh.uv_layers:
             dotextures = True
         else:
             tangents = 0

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -606,18 +606,19 @@ def merge( objects ):
     
     return bpy.context.active_object
 
-def get_merge_group( ob, prefix='merge.' ):
+def get_merge_group( ob, prefix='merge' ):
     m = []
     for grp in ob.users_collection:
-        if grp.name.lower().startswith(prefix): m.append( grp )
+        if grp.name.lower().startswith(prefix + "."):
+            m.append( grp )
     if len(m)==1:
         #if ob.data.users != 1:
-        #    logger.warn( 'An instance can not be in a merge group' )
+        #    logger.warn( 'An instance cannot be in a merge group' )
         #    return
         return m[0]
     elif m:
-        logger.warn('An object can not be in two merge groups at the same time: %s' % ob.name)
-        return
+        logger.warn('Object %s in two %s groups at the same time' % (ob.name, prefix))
+        return None
 
 def wordwrap( txt ):
     r = ['']


### PR DESCRIPTION
 - Made get_merge_group() more generic
 - Fix exporting problems with the array modifier
 - Add instancing support (static / instancing) to scene.py
 - Change location of tangent warning to mesh.py where it makes more sense
 - Document the new feature