### PR TITLE
Change filepath logic to resemble the Blender .OBJ official exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
  - [Updating to new versions](#updating-to-new-versions)
  - [Video Tutorials](#video-tutorials)
  - [Exporting Meshes](#exporting-meshes)
-   	- [Output Filenames](#output-filenames)
 	- [OgreNext Tips](#ogrenext-tips)
  - [Importing Meshes](#importing-meshes)
  - [Additional Features](#additional-features)
@@ -50,15 +49,6 @@ To export a blender model: `File Menu > Export > Ogre3D (.scene & .mesh)`. If th
 
 - If you have `OGRETOOLS_XML_CONVERTER` set to a "OgreXMLConverter.exe" path, then the export dialogue will display options relevant for the Ogre (v1) mesh format.
 - If you have `OGRETOOLS_XML_CONVERTER` set to a "OgreMeshTool.exe" path, then the export dialogue will display options relevant for the OgreNext (v2) mesh format. 
-
-#### Output Filenames
-The output file names are determined as per the following:
-![Output filenames example](images/Readme-ExportFilename-Example1.png)
-* If the collection name (Yellow box 1) *doesn't* have the prefix "merge." then the mesh filename is taken from the Scene Collection Node at location `[Red box 3]`. In this example: **CubeBig.mesh**
-* If the collection name (Yellow box 1) *does* have the prefix "merge." then the mesh filename is taken from the Scene Collection Node at location `[Yellow box 1, minus the 'merge.' prefix ]`. In this example: **CubeMerge.mesh**
-	- For more information on merging see the heading: [Merge Objects on export](#merge-objects-on-export)
-* The material filename is taken from the export dialogue filename text box at location `[Red box 2]`. The ".material" file extension is automatically added. In this example the output material name would be: **CubeSmall.material**
-* The material definition names are taken from the material names in the Scene Collection Node `[Red box 4]`. In this example: **CubeMaterial**
 
 #### OgreNext tips
 If you do want to export in the OgreNext (v2.) format, make sure in the `Export dialogue > General Settings > Mesh Export Version` is set to V2. The following parameters are a good start point to get a model exported to an Ogre mesh:

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -66,6 +66,19 @@ class _OgreCommonExport_(object):
                 # todo: isn't the key missing the "EX_" prefix?
                 setattr(self,key,value)
 
+        if not self.filepath:
+            blend_filepath = context.blend_data.filepath
+            if not blend_filepath:
+                blend_filepath = "blender2ogre"
+            else:
+                blend_filepath = os.path.splitext(blend_filepath)[0]
+
+            self.filepath = blend_filepath + ".scene"
+
+        logger.debug("Context.blend_data: %s" % context.blend_data.filepath)
+        logger.debug("Context.scene.name: %s" % context.scene.name)
+        logger.debug("Self.filepath: %s" % self.filepath)
+
         wm = context.window_manager
         fs = wm.fileselect_add(self)
         
@@ -128,30 +141,8 @@ class _OgreCommonExport_(object):
               "Cannot find suitable OgreXMLConverter or OgreMeshTool executable." +
               "Export XML mesh - do NOT automatically convert .xml to .mesh file. You MUST run converter mesh manually.")
 
-        logger.debug("Context.blend_data: %s" % context.blend_data.filepath)
-        logger.debug("Context.scene.name: %s" % context.scene.name)
-        logger.debug("Self.filepath: %s" % self.filepath)
-        logger.debug("Self.last_export_path: %s" % self.last_export_path)
-
         # Load addonPreference in CONFIG
         config.update_from_addon_preference(context)
-
-        # Resolve path from opened .blend if available. 
-        # Normally it's not if blender was opened with "Recover Last Session".
-        # After export is done once, remember that path when re-exporting.
-        if not self.last_export_path:
-            # First export during this blender run
-            if context.blend_data.filepath != "":
-                path, name = os.path.split(context.blend_data.filepath)
-                self.last_export_path = os.path.join(path, name.split('.')[0])
-
-        if not self.last_export_path:
-            self.last_export_path = os.path.expanduser("~")
-
-        if self.filepath == "" or not self.filepath:
-            self.filepath = "blender2ogre"
-
-        logger.debug("Self.filepath: %s" % self.filepath)
 
         kw = {}
         for name in dir(_OgreCommonExport_):

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -48,8 +48,6 @@ def menu_func(self, context):
 
 class _OgreCommonExport_(object):
 
-    last_export_path = None
-
     @classmethod
     def poll(cls, context):
         if context.active_object and context.mode != 'EDIT_MESH':


### PR DESCRIPTION
Issue #141 has been a pretty common annoyance for me as well.

I tried to solve this before with no success.

Checking the source code of the Blender official .OBJ exporter I see what the solution looks like.

The problem was that many times when choosing to export something the name of the file was empty, if the user was not careful and did not type a filename then Blender puts everything into the parent folder.

Now there is a default file name for every occasion so this should not happen again.