### PR TITLE
Fix Custom and Shape Normals

### DIFF
--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -5,9 +5,9 @@ from bpy.props import *
 logger = logging.getLogger('config')
 
 AXIS_MODES =  [
-    ('xyz', 'xyz', 'no swapping'),
-    ('xz-y', 'xz-y', 'ogre standard'),
-    ('-xzy', '-xzy', 'non standard'),
+    ('xyz', 'xyz', 'No Axis swapping'),
+    ('xz-y', 'xz-y', 'Ogre standard'),
+    ('-xzy', '-xzy', 'Non standard'),
 ]
 
 MESH_TOOL_VERSIONS = [
@@ -16,9 +16,9 @@ MESH_TOOL_VERSIONS = [
 ]
 
 TANGENT_MODES =  [
-    ('0', 'none', 'do not export'),
-    ('3', 'generate', 'generate'),
-    ('4', 'generate with parity', 'generate with parity')
+    ('0', 'none', 'Do not export tangents'),
+    ('3', 'generate', 'Generate tangents'),
+    ('4', 'generate with parity', 'Generate with parity')
 ]
 
 CONFIG_PATH = bpy.utils.user_resource('CONFIG', path='scripts', create=True)

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -670,6 +670,8 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
                                 'index' : str(vidx)
                         })
 
+                del _remap_normals_
+
                 doc.end_tag('pose')
             doc.end_tag('poses')
 
@@ -726,7 +728,6 @@ def dot_mesh( ob, path, force_name=None, ignore_shape_animation=False, normals=T
         del bm
 
         del _remap_verts_
-        del _remap_normals_
         del _face_indices_
         doc.close() # reported by Reyn
         f.close()


### PR DESCRIPTION
Hello @paroj,

I'm submitting this patch before I get too carried away with the changes.

These are the improvements:
 - Make clear use of tangents variable in conditionals since the type is not boolean
 - Make clear use of length comparison in conditionals since the type is not boolean
 - Fix normals by using: `mesh.loops[ loop_idx ].normal` for all shading types
 - Fix Shape Normals using `skey.normals_split_get()` for all shading types

This was tested with the following Blender versions: Blender 2.83.19, 2.93.8 and 3.3.2 (all the LTS versions).

I have tested everything I could think of in terms of Custom Normals, Shape Normals and Shape Animations.

The issue I mentioned about triangulation:
Suzanne without triangulation | Suzanne with `Triangulate` Modifier
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/5248597/213453100-8aebda7d-c8bf-49bd-99b5-c64c1cf0418b.png)  |  ![image](https://user-images.githubusercontent.com/5248597/213453158-a46fff09-d5e6-49b7-9e75-adc77d8d5d9b.png)

This can be blamed on the artist, it is reffered as having non-planar faces (basically, not the exporters fault).
Blender has tools to detect them and also to correct them, but in theory artist should be careful not to create them to have proper topology.

Another issue I stumbled upon is that we are triangulating by using this operation: `bmesh.ops.triangulate(bm, faces=bm.faces)`

From what I could see in my tests this operation is very similar (perhaps same code) to using the `Triangulate` Modifier.

You can see here that the modifier produces distortion with Custom Normals:
Torus without triangulation | Torus with `Triangulate` Modifier
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/5248597/215348724-aca5282f-e838-4eb4-a069-a10cd330c1df.png)  |  ![image](https://user-images.githubusercontent.com/5248597/215348860-c34ad107-d1ba-40bc-ba09-52d455d949bd.png)

Seems to be an unfixed Blender issue:
 - [Triangulate modifier breaks custom normals](https://developer.blender.org/T61942)
 - [Bmesh module does not support smooth shading / split normals](https://developer.blender.org/T45151)

One workaround/fix to that problem is selecting the mesh, going into Edit Mode and doing `Triangulate Faces` (Ctrl-T).
Of course any modifiers should be applied first.

I wonder if this merits a PSA in the forums for people to test the changes.
