### PR TITLE
Better handling of read and write access patterns

### DIFF
--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -143,7 +143,9 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
         with open(target_file, 'w') as f:
             f.flush()
     except Exception as e:
-        show_dialog("Invalid mesh object name: %s" % obj_name)
+        logger.error("Unable to create mesh file: %s" % target_file)
+        logger.error(e)
+        Report.errors.append("Unable to create mesh file: %s" % target_file)
         return []
 
     with open(target_file, 'w') as f:

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -213,9 +213,14 @@ def dot_scene(path, scene_name=None):
     # Create the .scene file
     if config.get('SCENE'):
         data = doc.toprettyxml()
-        with open(target_scene_file, 'wb') as fd:
-            fd.write(bytes(data,'utf-8'))
-        logger.info("- Exported Ogre Scene: %s " % target_scene_file)
+        try:
+            with open(target_scene_file, 'wb') as fd:
+                fd.write(bytes(data,'utf-8'))
+            logger.info("- Exported Ogre Scene: %s " % target_scene_file)
+        except Exception as e:
+            logger.error("Unable to create scene file: %s" % target_scene_file)
+            logger.error(e)
+            Report.errors.append("Unable to create scene file: %s" % target_scene_file)
 
     # Remove temporary objects/meshes
     for ob in temps:

--- a/io_ogre/properties.py
+++ b/io_ogre/properties.py
@@ -3,8 +3,8 @@ from bpy.props import BoolProperty, StringProperty, FloatProperty, IntProperty, 
 from .ogre.material import IMAGE_FORMATS, load_user_materials
 
 load_user_materials()
-# Rendering
 
+## Rendering
 bpy.types.Object.use_draw_distance = BoolProperty(
     name='enable draw distance',
     description='use LOD draw distance',
@@ -27,7 +27,6 @@ bpy.types.Object.multires_lod_range = FloatProperty(
     default=30.0, min=0.0, max=10000.0)
 
 ## Physics
-
 _physics_modes =  [
     ('NONE', 'NONE', 'no physics'),
     ('RIGID_BODY', 'RIGID_BODY', 'rigid body'),
@@ -72,8 +71,8 @@ bpy.types.Object.subcollision = BoolProperty(
     name="collision compound",
     description="member of a collision compound",
     default=False)
-## Sound
 
+## Sound
 bpy.types.Speaker.play_on_load = BoolProperty(
     name='play on load',
     default=False)
@@ -120,7 +119,7 @@ bpy.types.Image.resize_y = IntProperty(
     description='only if image is larger than defined, use ImageMagick to resize it down',
     default=256, min=2, max=4096)
 
-# Materials
+## Materials
 bpy.types.Material.use_material_passes = BoolProperty(
     # hidden option - gets turned on by operator
     # todo: What is a hidden option, is this needed?
@@ -167,4 +166,3 @@ bpy.types.World.ogre_skyX_cloud_density_y = FloatProperty(
     description="change density of volumetric clouds on Y",
     default=1.0,
     min=0.0, max=5.0)
-

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -137,8 +137,9 @@ class _OgreCommonExport_(object):
         # Add warning about missing XML converter
         if self.converter == "unknown":
             Report.errors.append(
-              "Cannot find suitable OgreXMLConverter or OgreMeshTool executable." +
-              "Export XML mesh - do NOT automatically convert .xml to .mesh file. You MUST run converter mesh manually.")
+              "Cannot find suitable OgreXMLConverter or OgreMeshTool executable.\n" +
+              "Exported XML mesh was NOT automatically converted to .mesh file.\n" + 
+              "You MUST run the converter manually to create binary .mesh file.")
 
         # Load addonPreference in CONFIG
         config.update_from_addon_preference(context)
@@ -168,26 +169,30 @@ class _OgreCommonExport_(object):
             log_file = ("%s/blender2ogre.log" % target_path)
             logger.info("* Writing log file to: %s" % log_file)
 
-            file_handler = logging.FileHandler(filename=log_file, mode='w', encoding='utf-8', delay=False)
+            try:
+                file_handler = logging.FileHandler(filename=log_file, mode='w', encoding='utf-8', delay=False)
 
-            # Show the python file name from where each log message originated
-            SHOW_LOG_NAME = False
+                # Show the python file name from where each log message originated
+                SHOW_LOG_NAME = False
 
-            if SHOW_LOG_NAME:
-                file_formatter = logging.Formatter(fmt='%(asctime)s %(name)9s.py [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-            else:
-                file_formatter = logging.Formatter(fmt='%(asctime)s [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+                if SHOW_LOG_NAME:
+                    file_formatter = logging.Formatter(fmt='%(asctime)s %(name)9s.py [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+                else:
+                    file_formatter = logging.Formatter(fmt='%(asctime)s [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
 
-            file_handler.setFormatter(file_formatter)
+                file_handler.setFormatter(file_formatter)
 
-            if config.get('DEBUG_LOGGING') == True:
-                level = logging.DEBUG
-            else:
-                level = logging.INFO
+                if config.get('DEBUG_LOGGING') == True:
+                    level = logging.DEBUG
+                else:
+                    level = logging.INFO
 
-            for logger_name in logging.Logger.manager.loggerDict.keys():
-                logging.getLogger(logger_name).addHandler(file_handler)
-                logging.getLogger(logger_name).setLevel(level)
+                for logger_name in logging.Logger.manager.loggerDict.keys():
+                    logging.getLogger(logger_name).addHandler(file_handler)
+                    logging.getLogger(logger_name).setLevel(level)
+            except Exception as e:
+                logger.warn("Unable to create log file: %s" % log_file)
+                logger.warn(e)
 
         logger.info("* Target path: %s" % target_path)
         logger.info("* Target file name: %s" % target_file_name)
@@ -206,7 +211,7 @@ class _OgreCommonExport_(object):
         Report.show()
 
         # Flush and close all logging file handlers
-        if config.get('ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') == True and file_handler != None:
             for logger_name in logging.Logger.manager.loggerDict.keys():
                 logging.getLogger(logger_name).handlers.clear()
             

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -180,7 +180,8 @@ def detect_converter_type():
         proc = subprocess.Popen([exe], stdout=subprocess.PIPE)
         output, _ = proc.communicate()
         output = output.decode('utf-8')
-    except:
+    except Exception as e:
+        logger.warn(e)
         output = ""
 
     if output.find("OgreXMLConverter") != -1:


### PR DESCRIPTION
In some cases the user might mistakenly select directories where Blender has no read or write access.

Particularly bad is the case of the 'USER_MATERIALS' option, that traverses the directory structure recursively and prevents the `blender2ogre` plugin from starting when it encounters a directory where there is no read access.

This fixes issue #175 