### PR TITLE
Improved Alpha channel and Transparency for exporting JSON material

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -838,50 +838,5 @@ def gather_metallic_roughness_texture(mat_wrapper):
 
     return ShaderImageTextureWrapper(node_image)
 
-def gather_alpha_texture(mat_wrapper):
-    
-    material = mat_wrapper.material
-
-    logger.debug("Getting Alpha texture of material: '%s'" % material.name)
-
-    input_name = 'Alpha'
-
-    base_return = (None, 1)
-
-    logger.debug(" + Processing input: '%s'" % input_name)
-
-    if material.use_nodes == False:
-        logger.warn("Material: '%s' does not use nodes" % material.name)
-        return base_return
-
-    if 'Principled BSDF' not in  material.node_tree.nodes:
-        logger.warn("Material: '%s' does not have a 'Principled BSDF' node" % material.name)
-        return base_return
-
-    input = material.node_tree.nodes['Principled BSDF'].inputs[input_name]
-
-    # Check that input is connected to a node
-    if len(input.links) > 0:
-        alpha_node = input.links[0].from_node
-    else:
-        logger.warn("%s input is not connected" % input_name)
-        return base_return
-
-    # Check that connected node is of type 'TEX_IMAGE'
-    if alpha_node.type in ['TEX_IMAGE']:
-        node_image = alpha_node
-        alpha = 1.0
-    elif alpha_node.type in ['MAP_RANGE']:
-        # Check that input is connected to an image texture
-        node_image = alpha_node.inputs[0].links[0].from_node
-        if node_image.type not in ['TEX_IMAGE']:
-            logger.warn("map range node has no input texture")
-            return base_return
-        alpha = alpha_node.inputs["To Max"].default_value
-    else:
-        logger.warn("Connected node '%s' is not of type 'TEX_IMAGE' or 'MAP_RANGE'" % alpha_node.name)
-        return base_return
-    
-    return (ShaderImageTextureWrapper(node_image), alpha)
 
 

--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -837,3 +837,51 @@ def gather_metallic_roughness_texture(mat_wrapper):
             return None
 
     return ShaderImageTextureWrapper(node_image)
+
+def gather_alpha_texture(mat_wrapper):
+    
+    material = mat_wrapper.material
+
+    logger.debug("Getting Alpha texture of material: '%s'" % material.name)
+
+    input_name = 'Alpha'
+
+    base_return = (None, 1)
+
+    logger.debug(" + Processing input: '%s'" % input_name)
+
+    if material.use_nodes == False:
+        logger.warn("Material: '%s' does not use nodes" % material.name)
+        return base_return
+
+    if 'Principled BSDF' not in  material.node_tree.nodes:
+        logger.warn("Material: '%s' does not have a 'Principled BSDF' node" % material.name)
+        return base_return
+
+    input = material.node_tree.nodes['Principled BSDF'].inputs[input_name]
+
+    # Check that input is connected to a node
+    if len(input.links) > 0:
+        alpha_node = input.links[0].from_node
+    else:
+        logger.warn("%s input is not connected" % input_name)
+        return base_return
+
+    # Check that connected node is of type 'TEX_IMAGE'
+    if alpha_node.type in ['TEX_IMAGE']:
+        node_image = alpha_node
+        alpha = 1.0
+    elif alpha_node.type in ['MAP_RANGE']:
+        # Check that input is connected to an image texture
+        node_image = alpha_node.inputs[0].links[0].from_node
+        if node_image.type not in ['TEX_IMAGE']:
+            logger.warn("map range node has no input texture")
+            return base_return
+        alpha = alpha_node.inputs["To Max"].default_value
+    else:
+        logger.warn("Connected node '%s' is not of type 'TEX_IMAGE' or 'MAP_RANGE'" % alpha_node.name)
+        return base_return
+    
+    return (ShaderImageTextureWrapper(node_image), alpha)
+
+

--- a/io_ogre/ogre/materialv2json.py
+++ b/io_ogre/ogre/materialv2json.py
@@ -188,6 +188,12 @@ class OgreMaterialv2JsonGenerator(object):
         }
         if tex_filename:
             datablock["metalness"]["texture"] = os.path.split(tex_filename)[-1]
+            datablock["metalness"]["value"] = 0.818  # default mtallic value according to the docs
+        else:  # Support for standalone metallic texture
+            tex_filename = self.prepare_texture(bsdf.metallic_texture)[0]
+            if tex_filename:
+                datablock["metalness"]["texture"] = os.path.split(tex_filename)[-1]
+                datablock["metalness"]["value"] = 0.818
 
         # Set up normalmap parameters, only if texture is present
         tex_filename = self.prepare_texture(bsdf.normalmap_texture)[0]
@@ -206,6 +212,12 @@ class OgreMaterialv2JsonGenerator(object):
         }
         if tex_filename:
             datablock["roughness"]["texture"] = os.path.split(tex_filename)[-1]
+            datablock["roughness"]["value"] = 1.0 # default roughness value according to the docs
+        else:  # Support for standalone roughness texture
+            tex_filename = self.prepare_texture(bsdf.roughness_texture)[0]
+            if tex_filename:
+                datablock["roughness"]["texture"] = os.path.split(tex_filename)[-1]
+                datablock["roughness"]["value"] = 1.0
 
         # Set up specular parameters
         logger.debug("Specular params")

--- a/io_ogre/ogre/materialv2json.py
+++ b/io_ogre/ogre/materialv2json.py
@@ -165,7 +165,7 @@ class OgreMaterialv2JsonGenerator(object):
         tex_filename, diffuse_tex_src = self.prepare_texture(diffuse_tex)
         if tex_filename:
             datablock["diffuse"]["texture"] = os.path.split(tex_filename)[-1]
-            datablock["diffuse"]["value"] = [1.0, 1.0, 1.0, 1.0]
+            datablock["diffuse"]["value"] = [1.0, 1.0, 1.0]
             diffuse_tex_dst = tex_filename
 
 

--- a/io_ogre/ogre/materialv2json.py
+++ b/io_ogre/ogre/materialv2json.py
@@ -162,11 +162,11 @@ class OgreMaterialv2JsonGenerator(object):
             "value": bsdf.base_color[0:3]
         }
         diffuse_tex = bsdf.base_color_texture
-        tex_filename, diffuse_tex_dst = self.prepare_texture(diffuse_tex)
+        tex_filename, diffuse_tex_src = self.prepare_texture(diffuse_tex)
         if tex_filename:
             datablock["diffuse"]["texture"] = os.path.split(tex_filename)[-1]
             datablock["diffuse"]["value"] = [1.0, 1.0, 1.0, 1.0]
-            diffuse_tex_src = tex_filename
+            diffuse_tex_dst = tex_filename
 
 
         # Set up emissive parameters
@@ -221,9 +221,8 @@ class OgreMaterialv2JsonGenerator(object):
          # Initialize blendblock
         blendblocks = {}
         alpha_tex, alpha_strength = gather_alpha_texture(bsdf)
-        tex_filename, alpha_tex_dst = self.prepare_texture(alpha_tex)
+        tex_filename, alpha_tex_src = self.prepare_texture(alpha_tex)
         if tex_filename:
-            alpha_tex_src = tex_filename
             datablock["alpha_test"] = ["greater_equal", material.alpha_threshold, False]
 
             # Give blendblock common settings
@@ -361,7 +360,7 @@ class OgreMaterialv2JsonGenerator(object):
             self.copy_set.add((src_filename, dst_filename))
 
         #return os.path.split(dst_filename)[-1]
-        return src_filename, dst_filename
+        return dst_filename, src_filename
 
     def copy_textures(self):
         """Copy and/or convert textures from previous prepare_texture() calls"""


### PR DESCRIPTION
_Images plugged into "Principled BSDF" 's Alpha will combine with Images at BaseColor as the alpha channel (Since Ogre use 1 image for both color and alpha).

_More options for texture's BlendBlock, controlled by Blender's 3 Blend modes:
* Alpha Clip = just Blend Type: REPLACE
* Alpha Blend = a BlendBlock with custom setting, very transparent
* Alpha Hashed =  a BlendBlock with custom setting but less transparent than Alpha Blend

_There was also plan for supporting other texture nodes aside from image, but I couldn't find a way to get the node's color matrices

Edit: The image texture needs to be plugged in the "Value" input a "map range" node and then connect "Result" to the Alpha channel (like how metallic and roughness texture is plugged in through a "separate colore" node). 
This is so that "Map range" 's "To Max" value can be used to modify the Transparency strength, which is determined by ["Transparency"]["value"] in the .material.json file.

Here's what my setup look like for combining Base Color texture and Alpha texture:
![image](https://github.com/OGRECave/blender2ogre/assets/86541274/82193a52-7c31-43b8-ba7c-d2d6ed605267)

And here are the results for the 3 Blend mode setting:
*Alpha Clip
![image](https://github.com/OGRECave/blender2ogre/assets/86541274/88869a23-2b68-41d1-bc72-2f5669c54afc)
*Alpha Blend
![image](https://github.com/OGRECave/blender2ogre/assets/86541274/69e1e8e6-5638-499a-9505-d5e4029a07ad)
*Alpha Hashed
![image](https://github.com/OGRECave/blender2ogre/assets/86541274/f5cbbde4-7540-43c2-87d7-0cd7894b10f8)

Alpha Blend is very hard to see, but is definitely there
* Also note that these Blend modes just decide the "style" of Blending, not the Transparent strength even if they look like they do. The Transparent strength is decided by the "To Max" value of "Map range node". These 3 modes also output the same combined texture.