### PR TITLE
Fix for removal of 'use_inherit_scale'

### DIFF
--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -146,7 +146,8 @@ class Bone(object):
                 self.ogreDerivedScale[1] *= self.parent.ogreDerivedScale[1]
                 self.ogreDerivedScale[2] *= self.parent.ogreDerivedScale[2]
                 # if we don't want inherited scale,
-                if not self.bone.bone.use_inherit_scale:
+                # https://docs.blender.org/api/2.83/bpy.types.Bone.html#bpy.types.Bone.inherit_scale
+                if self.bone.bone.inherit_scale == 'NONE' or self.bone.bone.inherit_scale == 'NONE_LEGACY':
                     # cancel out the scale that Ogre will calculate
                     scl = self.parent.ogreDerivedScale
                     self.pose_scale = mathutils.Vector((1.0/scl[0], 1.0/scl[1], 1.0/scl[2]))
@@ -156,7 +157,8 @@ class Bone(object):
             # just output the scale directly
             self.pose_scale = pbone.scale.copy()
             # however, if Blender is inheriting the scale,
-            if self.parent and self.bone.bone.use_inherit_scale:
+            # https://docs.blender.org/api/2.83/bpy.types.Bone.html#bpy.types.Bone.inherit_scale
+            if self.parent and self.bone.bone.inherit_scale == 'AVERAGE':
                 # apply parent's scale (only works for uniform scaling)
                 self.pose_scale[0] *= self.parent.pose_scale[0]
                 self.pose_scale[1] *= self.parent.pose_scale[1]


### PR DESCRIPTION
In Blender 4.0, the `Bone` property: `use_inherit_scale` has been removed [Changes in Blender’s Python API between releases 3.6 to 4.0](https://docs.blender.org/api/4.0/change_log.html#id7) // [Anim: remove the deprecated use_inherit_scale bone property.](https://github.com/blender/blender/commit/2abd026cfedaecbb0be039c02f2aa142cef3fc09).

This has been reported here: [Blender Exporter Animation Crash](https://forums.ogre3d.org/viewtopic.php?t=97202)
