### PR TITLE
Add option for exporting manual LOD levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 	- [Exporting Shape (or Pose) Animations](#exporting-shape-animations)
 	- [Exporting Node Animations](#exporting-node-animations)
 	- [Exporting for Physics](#exporting-for-physics)
+	- [Level of Detail (LOD)](#level-of-detail--lod-)
  	- [Mesh Previewer](#mesh-previewer)
  - [About](#about)
  - [Authors](#authors)
@@ -250,6 +251,16 @@ Check out the [Node Animations](NodeAnimations.md) tutorial to see how to create
 
 ### Exporting for Physics
 Check out the [Exporting for Physics](Physics.md) tutorial to see some techniques and optimizations when exporting collision meshes for Physics Engines
+
+### Level of Detail (LOD)
+Level of Detail or LOD is an optimization technique supported by OGRE, where meshes that are far away from the camera are replaced by meshes with lower vertex count.
+Because you can get away with less detailed models when they are in the distance this optimizacion technique is very common in games especially.
+With `blender2ogre` there are three ways to generate LOD levels for a mesh:
+ * `OgreMesh Tools`: This method uses the tool `OgreMeshUpgrader` to automatically generate the LOD levels for the mesh by removing edges. This allows only changing the index buffer and re-use the vertex-buffer (storage efficient)
+ * `Blender`: This method uses Blenders "Decimate" Modifier to automatically generate the LOD Leves by collapsing vertices. This can result in a visually better LOD, but needs different vertex-buffers per LOD
+ * `Manual`: This metod requires that the user manually create the aditional LOD levels for the mesh. The meshes should be called <base mesh>_LOD_1, <base mesh>_LOD_2, etc. This method gives better control over the resulting LODs.
+
+For the `Manual` it is currently not possible to manually set the distances for each LOD, but it is possible to have different materials for each LOD level.
 
 
 ### Mesh Previewer

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -21,6 +21,12 @@ TANGENT_MODES =  [
     ('4', 'generate with parity', 'Generate with parity')
 ]
 
+LOD_METHODS =  [
+    ('0', 'meshtools', 'Generate LODs using OgreMesh Tools: does LOD by removing edges, which allows only changing the index buffer and re-use the vertex-buffer (storage efficient)'),
+    ('1', 'blender', 'Generate LODs using Blenders "Decimate" Modifier: does LOD by collapsing vertices, which can result in a visually better LOD, but needs different vertex-buffers per LOD'),
+    ('2', 'manual', 'Generate LODs by manually crafting the lower LODs: needs different vertex-buffers per LOD')
+]
+
 CONFIG_PATH = bpy.utils.user_resource('CONFIG', path='scripts', create=True)
 CONFIG_FILENAME = 'io_ogre.pickle'
 CONFIG_FILEPATH = os.path.join(CONFIG_PATH, CONFIG_FILENAME)
@@ -75,10 +81,10 @@ _CONFIG_DEFAULTS_ALL = {
     'OPTIMISE_VERTEX_BUFFERS_OPTIONS' : 'puqs',
 
     # LOD
+    'LOD_GENERATION': '0',
     'LOD_LEVELS' : 0,
     'LOD_DISTANCE' : 300,
     'LOD_PERCENT' : 40,
-    'LOD_MESH_TOOLS' : False,
 
     # Pose Animation
     'SHAPE_ANIMATIONS' : True,

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -109,7 +109,7 @@ class _OgreCommonExport_(object):
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"],
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_SHARED_ARMATURE", "EX_ONLY_KEYFRAMES", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"],
             "Mesh" : ["EX_MESH", "EX_MESH_OVERWRITE", "EX_ARRAY", "EX_V1_EXTREMITY_POINTS", "EX_Vx_GENERATE_EDGE_LISTS", "EX_GENERATE_TANGENTS", "EX_Vx_OPTIMISE_ANIMATIONS", "EX_V2_OPTIMISE_VERTEX_BUFFERS", "EX_V2_OPTIMISE_VERTEX_BUFFERS_OPTIONS"],
-            "LOD" : ["EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT", "EX_LOD_MESH_TOOLS"],
+            "LOD" : ["EX_LOD_GENERATION", "EX_LOD_LEVELS", "EX_LOD_DISTANCE", "EX_LOD_PERCENT"],
             "Shape Animation" : ["EX_SHAPE_ANIMATIONS", "EX_SHAPE_NORMALS"],
             "Logging" : ["EX_Vx_ENABLE_LOGGING", "EX_Vx_DEBUG_LOGGING"]
         }
@@ -397,6 +397,11 @@ S - strips the buffers for shadow mapping (consumes less space and memory)""",
         default=config.get('OPTIMISE_VERTEX_BUFFERS_OPTIONS')) = {}
 
     # LOD
+    EX_LOD_GENERATION : EnumProperty(
+        items=config.LOD_METHODS,
+        name='LOD Generation Method',
+        description='Method of generating LOD levels',
+        default=config.get('LOD_METHODS')) = {}    
     EX_LOD_LEVELS : IntProperty(
         name="LOD Levels",
         description="Number of LOD levels",
@@ -412,12 +417,6 @@ S - strips the buffers for shadow mapping (consumes less space and memory)""",
         description="LOD percentage reduction",
         min=0, max=99,
         default=config.get('LOD_PERCENT')) = {}
-    EX_LOD_MESH_TOOLS : BoolProperty(
-        name="Use OgreMesh Tools",
-        description="""Use OgreMeshUpgrader/OgreMeshTool instead of Blender to generate the mesh LODs.
-OgreMeshUpgrader/OgreMeshTool does LOD by removing edges, which allows only changing the index buffer and re-use the vertex-buffer (storage efficient).
-Blenders decimate does LOD by collapsing vertices, which can result in a visually better LOD, but needs different vertex-buffers per LOD.""",
-        default=config.get('LOD_MESH_TOOLS')) = {}
 
     # Pose Animation
     EX_SHAPE_ANIMATIONS : BoolProperty(

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -83,7 +83,7 @@ def mesh_upgrade_tool(infile):
     if not os.path.exists(infile):
         logger.warn("Cannot find file mesh file: %s, unable run OgreMeshUpgrader" % filename)
 
-        if config.get('LOD_MESH_TOOLS') == True:
+        if config.get('LOD_GENERATION') == '0':
             Report.warnings.append("OgreMeshUpgrader failed, LODs will not be generated for this mesh: %s" % filename)
 
         if config.get('GENERATE_EDGE_LISTS') == True:
@@ -107,7 +107,7 @@ def mesh_upgrade_tool(infile):
 
     cmd = [exe]
 
-    if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+    if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
         cmd.append('-l')
         cmd.append(str(config.get('LOD_LEVELS')))
 
@@ -134,7 +134,7 @@ def mesh_upgrade_tool(infile):
     # Finally, specify input file
     cmd.append(infile)
 
-    if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+    if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
         logger.info("* Generating %s LOD levels for mesh: %s" % (config.get('LOD_LEVELS'), filename))
 
     if config.get('GENERATE_EDGE_LISTS') == True:
@@ -153,7 +153,7 @@ def mesh_upgrade_tool(infile):
     if proc.returncode != 0:
         logger.warn("OgreMeshUpgrader failed, LODs / Edge Lists / Vertex buffer optimizations will not be generated for this mesh: %s" % filename)
 
-        if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+        if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
             Report.warnings.append("OgreMeshUpgrader failed, LODs will not be generated for this mesh: %s" % filename)
 
         if config.get('GENERATE_EDGE_LISTS') == True:
@@ -163,7 +163,7 @@ def mesh_upgrade_tool(infile):
             logger.error(error)
         logger.warn(output)
     else:
-        if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+        if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
             logger.info("- Generated %s LOD levels for mesh: %s" % (config.get('LOD_LEVELS'), filename))
 
         if config.get('GENERATE_EDGE_LISTS') == True:
@@ -341,7 +341,7 @@ def xml_convert(infile, has_uvs=False):
         cmd.append('-%s' %config.get('MESH_TOOL_VERSION'))
 
         # If requested by the user, generate LOD levels through OgreMeshUpgrader/OgreMeshTool
-        if config.get('LOD_LEVELS') > 0 and config.get('LOD_MESH_TOOLS') == True:
+        if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
             cmd.append('-l')
             cmd.append(str(config.get('LOD_LEVELS')))
             


### PR DESCRIPTION
The exporter was missing an option to manually create LOD levels #189 

Now it is possible to create meshes with name "[base mesh]_LOD_n" and `blender2ogre` will automatically export those meshes as LOD levels for "[base mesh]".

The new feature has been documented and also the exporting code has been modified to ignore objets with _\_LOD\__ in the name when the option to export manual LODs has been selected.
