### PR TITLE
Replace isclose for math.isclose native method

### DIFF
--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -1,6 +1,7 @@
 import os, time, sys, logging
 import bmesh
 import mathutils
+import math
 
 # When bpy is already in local, we know this is not the initial import...
 if "bpy" in locals():
@@ -900,73 +901,6 @@ def append_triangle_in_vertex_group(mesh, obj, vertex_groups, ogre_indices, blen
             vertex_groups[name] = []
         vertex_groups[name].append(ogre_indices)
 
-import cmath
-def isclose(a,
-            b,
-            rel_tol=1e-9,
-            abs_tol=0.0,
-            method='weak'):
-    ### copied from PEP 485. when blender switches to python 3.5 use math.isclose(...)
-    """
-    returns True if a is close in value to b. False otherwise
-    :param a: one of the values to be tested
-    :param b: the other value to be tested
-    :param rel_tol=1e-8: The relative tolerance -- the amount of error
-                         allowed, relative to the magnitude of the input
-                         values.
-    :param abs_tol=0.0: The minimum absolute tolerance level -- useful for
-                        comparisons to zero.
-    :param method: The method to use. options are:
-                  "asymmetric" : the b value is used for scaling the tolerance
-                  "strong" : The tolerance is scaled by the smaller of
-                             the two values
-                  "weak" : The tolerance is scaled by the larger of
-                           the two values
-                  "average" : The tolerance is scaled by the average of
-                              the two values.
-    NOTES:
-    -inf, inf and NaN behave similar to the IEEE 754 standard. That
-    -is, NaN is not close to anything, even itself. inf and -inf are
-    -only close to themselves.
-    Complex values are compared based on their absolute value.
-    The function can be used with Decimal types, if the tolerance(s) are
-    specified as Decimals::
-      isclose(a, b, rel_tol=Decimal('1e-9'))
-    See PEP-0485 for a detailed description
-    """
-    if method not in ("asymmetric", "strong", "weak", "average"):
-        raise ValueError('method must be one of: "asymmetric",'
-                         ' "strong", "weak", "average"')
-
-    if rel_tol < 0.0 or abs_tol < 0.0:
-        raise ValueError('error tolerances must be non-negative')
-
-    if a == b:  # short-circuit exact equality
-        return True
-    # use cmath so it will work with complex or float
-    if cmath.isinf(a) or cmath.isinf(b):
-        # This includes the case of two infinities of opposite sign, or
-        # one infinity and one finite number. Two infinities of opposite sign
-        # would otherwise have an infinite relative tolerance.
-        return False
-    diff = abs(b - a)
-    if method == "asymmetric":
-        return (diff <= abs(rel_tol * b)) or (diff <= abs_tol)
-    elif method == "strong":
-        return (((diff <= abs(rel_tol * b)) and
-                 (diff <= abs(rel_tol * a))) or
-                (diff <= abs_tol))
-    elif method == "weak":
-        return (((diff <= abs(rel_tol * b)) or
-                 (diff <= abs(rel_tol * a))) or
-                (diff <= abs_tol))
-    elif method == "average":
-        return ((diff <= abs(rel_tol * (a + b) / 2) or
-                (diff <= abs_tol)))
-    else:
-        raise ValueError('method must be one of:'
-                         ' "asymmetric", "strong", "weak", "average"')
-
 class VertexNoPos(object):
     def __init__(self, ogre_vidx, nx,ny,nz, r,g,b,ra, vert_uvs):
         self.ogre_vidx = ogre_vidx
@@ -981,13 +915,13 @@ class VertexNoPos(object):
 
     '''does not compare ogre_vidx (and position at the moment) [ no need to compare position ]'''
     def __eq__(self, o):
-        if not isclose(self.nx, o.nx): return False
-        if not isclose(self.ny, o.ny): return False
-        if not isclose(self.nz, o.nz): return False
-        if not isclose(self.r, o.r): return False
-        if not isclose(self.g, o.g): return False
-        if not isclose(self.b, o.b): return False
-        if not isclose(self.ra, o.ra): return False
+        if not math.isclose(self.nx, o.nx): return False
+        if not math.isclose(self.ny, o.ny): return False
+        if not math.isclose(self.nz, o.nz): return False
+        if not math.isclose(self.r, o.r): return False
+        if not math.isclose(self.g, o.g): return False
+        if not math.isclose(self.b, o.b): return False
+        if not math.isclose(self.ra, o.ra): return False
         if len(self.vert_uvs) != len(o.vert_uvs): return False
         if self.vert_uvs:
             for i, uv1 in enumerate( self.vert_uvs ):


### PR DESCRIPTION
The method `math.isclose` has been added to python in version 3.5.

That version is even present in Blender 2.79b, so it is safe to do this replacement for Blender versions 2.8+ who carry even newer python versions:
- Blender 2.79: Python 3.5.3 (`math.isclose` is available)
- Blender 2.80 to 3.3: Python 3.9 (`math.isclose` is available)
- Blender 3.4 and newer: Python 3.10 (`math.isclose` is available)
