### PR TITLE
Separate deletion of XML files between importer and exporter

### DIFF
--- a/io_ogre/__init__.py
+++ b/io_ogre/__init__.py
@@ -17,7 +17,7 @@
 bl_info = {
     "name": "OGRE Importer-Exporter (.scene, .mesh, .skeleton)",
     "author": "Brett, S.Rombauts, F00bar, Waruck, Mind Calamity, Mr.Magne, Jonne Nauha, vax456, Richard Plangger, Pavel Rojtberg, Guillermo Ojea Quintana",
-    "version": (0, 8, 3),
+    "version": (0, 8, 5),
     "blender": (2, 80, 0),
     "location": "File > Import and Export...",
     "description": "Import and Export to and from Ogre xml and binary formats",

--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -33,9 +33,9 @@ CONFIG_FILEPATH = os.path.join(CONFIG_PATH, CONFIG_FILENAME)
 
 _CONFIG_DEFAULTS_ALL = {
     # General
-    'SWAP_AXIS' : 'xyz', # ogre standard is 'xz-y', but swapping is currently broken
+    'SWAP_AXIS' : 'xz-y',
     'MESH_TOOL_VERSION' : 'v2',
-    'XML_DELETE' : True,
+    'EXPORT_XML_DELETE' : True,
 
     # Scene
     'SCENE' : True,
@@ -96,6 +96,7 @@ _CONFIG_DEFAULTS_ALL = {
     #'SHOW_LOG_NAME' : False,
 
     # Import
+    'IMPORT_XML_DELETE' : False,
     'IMPORT_NORMALS' : True,
     'MERGE_SUBMESHES' : True,
     'IMPORT_ANIMATIONS' : True,
@@ -202,6 +203,8 @@ def get(name, default=None):
     global CONFIG
     if name in CONFIG:
         return CONFIG[name]
+    else:
+        logger.error("Config option %s does not exist!" % name)
     return default
 
 def update(**kwargs):

--- a/io_ogre/ogre/ogre_import.py
+++ b/io_ogre/ogre/ogre_import.py
@@ -1342,7 +1342,8 @@ def load(filepath):
         # Create skeleton (if any) and mesh from parsed data
         bCreateMesh(meshData, folder, onlyName, pathMeshXml)
         bCreateAnimations(meshData)
-        if config.get('XML_DELETE'):
+
+        if config.get('IMPORT_XML_DELETE') == True:
             # Cleanup by deleting the XML file we created
             os.unlink("%s" % pathMeshXml)
             if 'skeleton' in meshData:

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -103,7 +103,7 @@ class _OgreCommonExport_(object):
 
         # Options associated with each section
         section_options = {
-            "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_VERSION", "EX_XML_DELETE"],
+            "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_VERSION", "EX_EXPORT_XML_DELETE"],
             "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"],
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS", "EX_USE_FFP_PARAMETERS"],
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"],
@@ -253,15 +253,15 @@ class _OgreCommonExport_(object):
         name='Mesh Export Version',
         description='Specify Ogre version format to write',
         default=config.get('MESH_TOOL_VERSION')) = {}
-    EX_XML_DELETE : BoolProperty(
-        name="Clean up xml files",
-        description="Remove the generated xml files after binary conversion. \n(The removal will only happen if OgreXMLConverter/OgreMeshTool finishes successfully)",
-        default=config.get('XML_DELETE')) = {}
-    
+    EX_EXPORT_XML_DELETE : BoolProperty(
+        name="Clean up XML files",
+        description="Remove the generated XML files after binary conversion. \n(The removal will only happen if OgreXMLConverter/OgreMeshTool finishes successfully)",
+        default=config.get('EXPORT_XML_DELETE')) = {}
+
     # Scene
     EX_SCENE : BoolProperty(
         name="Export Scene",
-        description="Export current scene (OgreDotScene xml file)",
+        description="Export current scene (OgreDotScene XML file)",
         default=config.get('SCENE')) = {}
     EX_SELECTED_ONLY : BoolProperty(
         name="Export Selected Only",

--- a/io_ogre/ui/importer.py
+++ b/io_ogre/ui/importer.py
@@ -59,7 +59,7 @@ class _OgreCommonImport_(object):
 
         wm = context.window_manager
         fs = wm.fileselect_add(self)
-        
+
         return {'RUNNING_MODAL'}
 
     def draw(self, context):
@@ -77,16 +77,16 @@ class _OgreCommonImport_(object):
         section_icons = {
             "General" : "WORLD", "Armature" : "ARMATURE_DATA", "Mesh" : "MESH_DATA", "Shape Keys" : "ANIM_DATA", "Logging" : "TEXT"
         }
-        
+
         # Options associated with each section
         section_options = {
-            "General" : ["IM_SWAP_AXIS", "IM_V2_MESH_TOOL_VERSION", "IM_XML_DELETE"], 
+            "General" : ["IM_SWAP_AXIS", "IM_V2_MESH_TOOL_VERSION", "IM_IMPORT_XML_DELETE"], 
             "Armature" : ["IM_IMPORT_ANIMATIONS", "IM_ROUND_FRAMES", "IM_USE_SELECTED_SKELETON"], 
             "Mesh" : ["IM_IMPORT_NORMALS", "IM_MERGE_SUBMESHES"], 
             "Shape Keys" : ["IM_IMPORT_SHAPEKEYS"], 
             "Logging" : ["IM_Vx_ENABLE_LOGGING"]
         }
-        
+
         for section in sections:
             row = layout.row()
             box = row.box()
@@ -103,7 +103,7 @@ class _OgreCommonImport_(object):
                         box.prop(self, prop)
                 elif prop.startswith('IM_'):
                     box.prop(self, prop)
-        
+
     def execute(self, context):
         # Add warinng about missing XML converter
         Report.reset()
@@ -236,10 +236,10 @@ class _OgreCommonImport_(object):
         description='Specify Ogre version format to read',
         default=config.get('MESH_TOOL_VERSION')) = {}
 
-    IM_XML_DELETE : BoolProperty(
+    IM_IMPORT_XML_DELETE : BoolProperty(
         name="Clean up XML files",
         description="Remove the generated XML files after binary conversion. \n(The removal will only happen if OgreXMLConverter/OgreMeshTool finishes successfully)",
-        default=config.get('XML_DELETE')) = {}
+        default=config.get('IMPORT_XML_DELETE')) = {}
 
     # Mesh
     IM_IMPORT_NORMALS : BoolProperty(

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -351,12 +351,12 @@ def xml_convert(infile, has_uvs=False):
             logger.error("OgreXMLConverter returned with non-zero status, check OgreXMLConverter.log")
             logger.info(" ".join(cmd))
             Report.errors.append("OgreXMLConverter finished with non-zero status converting mesh: (%s), it might not have been properly generated" % name)
-        
+
         # Clean up .xml file after successful conversion
-        if proc.returncode == 0 and config.get('XML_DELETE') == True:
+        if proc.returncode == 0 and config.get('EXPORT_XML_DELETE') == True:
             logger.info("Removing generated xml file after conversion: %s" % infile)
             os.remove(infile)
-        
+
     else:
         # Convert to v2 format if required
         cmd.append('-%s' %config.get('MESH_TOOL_VERSION'))
@@ -390,7 +390,7 @@ def xml_convert(infile, has_uvs=False):
         if config.get('ENABLE_LOGGING'):
             logfile_path, name = os.path.split(infile)
             logfile = os.path.join(logfile_path, 'OgreMeshTool.log')
-        
+
             with open(logfile, 'w') as log:
                 log.write(output)
 
@@ -401,7 +401,7 @@ def xml_convert(infile, has_uvs=False):
             Report.errors.append("OgreMeshTool finished with non-zero status converting mesh: (%s), it might not have been properly generated" % name)
 
         # Clean up .xml file after successful conversion
-        if proc.returncode == 0 and config.get('XML_DELETE') == True:
+        if proc.returncode == 0 and config.get('EXPORT_XML_DELETE') == True:
             logger.info("Removing generated xml file after conversion: %s" % infile)
             os.remove(infile)
 


### PR DESCRIPTION
The importer and the exporter shared an option: `XML_DELETE` which can mislead an user and end up deleting an XML file

Also update version to 0.8.5, since the last time there was an oversight and the version remained in 0.8.3 with a release of 0.8.4