### PR TITLE
Correct al instances of `config.get()` to use singleton-comparison

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -206,7 +206,7 @@ class OgreMaterialGenerator(object):
                     self.w.iword('cull_hardware none').nl()
                     self.w.iword('depth_write off').nl()
 
-            if config.get('USE_FFP_PARAMETERS'):
+            if config.get('USE_FFP_PARAMETERS') is True:
                 # arbitrary bad translation from PBR to Blinn Phong
                 # derive proportions from metallic
                 bf = 1.0 - mat_wrapper.metallic

--- a/io_ogre/ogre/mesh.py
+++ b/io_ogre/ogre/mesh.py
@@ -88,8 +88,8 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
     # Don't export hidden or unselected objects unless told to
     if  not isLOD and (
         (config.get('LOD_GENERATION') == '2' and "_LOD_" in ob.name) or
-        (not config.get("EXPORT_HIDDEN") and ob not in bpy.context.visible_objects) or
-        (config.get("SELECTED_ONLY") and not ob.select_get())
+        ((config.get("EXPORT_HIDDEN") is False) and ob not in bpy.context.visible_objects) or
+        ((config.get("SELECTED_ONLY") is True) and not ob.select_get())
         ):
         logger.debug("Skip exporting hidden/non-selected object: %s" % ob.data.name)
         return []
@@ -108,13 +108,13 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
         # If we try to remove the unwanted modifiers from the copy object, then none of the modifiers will be applied when doing `to_mesh()`
 
         # If we want to optimise array modifiers as instances, then the Array Modifier should be disabled
-        if config.get("ARRAY") == True:
+        if config.get("ARRAY") is True:
             disable_mods = ['ARMATURE', 'ARRAY']
         else:
             disable_mods = ['ARMATURE']
 
         for mod in ob.modifiers:
-            if mod.type in disable_mods and mod.show_viewport == True:
+            if mod.type in disable_mods and mod.show_viewport is True:
                 logger.debug("Disabling Modifier: %s" % mod.name)
                 mod.show_viewport = False
 
@@ -622,7 +622,7 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
         arm = ob.find_armature()
         if arm:
             skeleton_name = obj_name
-            if config.get('SHARED_ARMATURE') == True:
+            if config.get('SHARED_ARMATURE') is True:
                 skeleton_name = arm.data.name
             skeleton_name = util.clean_object_name(skeleton_name)
 
@@ -634,7 +634,7 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
             boneIndexFromName = {}
             for bone in arm.pose.bones:
                 boneOutputEnableFromName[ bone.name ] = True
-                if config.get('ONLY_DEFORMABLE_BONES'):
+                if config.get('ONLY_DEFORMABLE_BONES') is True:
                     # if we found a deformable bone,
                     if bone.bone.use_deform:
                         # visit all ancestor bones and mark them "output enabled"
@@ -676,7 +676,7 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
             doc.end_tag('boneassignments')
 
         # Updated June3 2011 - shape animation works
-        if config.get('SHAPE_ANIMATIONS') and mesh.shape_keys and len(mesh.shape_keys.key_blocks) > 0:
+        if (config.get('SHAPE_ANIMATIONS') is True) and mesh.shape_keys and len(mesh.shape_keys.key_blocks) > 0:
             logger.info('* Writing shape keys')
 
             doc.start_tag('poses', {})
@@ -719,7 +719,7 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
                     pv = skey.data[ v.index ]
                     x,y,z = swap( pv.co - v.co )
 
-                    if config.get('SHAPE_NORMALS'):
+                    if config.get('SHAPE_NORMALS') is True:
                         vertex_idx = v.index
 
                         # Try to get original polygon loop index (before tesselation)
@@ -735,7 +735,7 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
                         pn = mathutils.Vector( snormals[normal_idx] )
                         nx,ny,nz = swap( pn )
 
-                    if config.get('SHAPE_NORMALS'):
+                    if config.get('SHAPE_NORMALS') is True:
                         doc.leaf_tag('poseoffset', {
                                 'x' : '%6f' % x,
                                 'y' : '%6f' % y,
@@ -844,10 +844,10 @@ def dot_mesh(ob, path, force_name=None, ignore_shape_animation=False, normals=Tr
 
     # If requested by the user, generate LOD levels / Edge Lists / Vertex buffer optimization through OgreMeshUpgrader
     if ((config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0') or
-        (config.get('GENERATE_EDGE_LISTS') == True)):
+        (config.get('GENERATE_EDGE_LISTS') is True)):
         target_mesh_file = os.path.join(path, '%s.mesh' % obj_name )
         util.mesh_upgrade_tool(target_mesh_file)
-    
+
     # Note that exporting the skeleton does not happen here anymore
     # It was moved to the function dot_skeleton in its own module (skeleton.py)
 

--- a/io_ogre/ogre/node_anim.py
+++ b/io_ogre/ogre/node_anim.py
@@ -97,10 +97,11 @@ def write_animation(ob, action, frame_start, frame_end, doc, xmlnode):
 
     _fps = float( bpy.context.scene.render.fps )
 
-    # Actually in Blender this does not make sense because there is only one possible animation per object, but lets maintain compatibility with Easy Ogre Exporter
+    # Actually in Blender this does not make sense because there is only one possible animation per object,
+    # but lets maintain compatibility with Easy Ogre Exporter
     aa = doc.createElement('animations')
     xmlnode.appendChild(aa)
-    
+
     a = doc.createElement('animation')
     a.setAttribute("name", "%s" % action.name)
     a.setAttribute("enable", "false")
@@ -111,7 +112,7 @@ def write_animation(ob, action, frame_start, frame_end, doc, xmlnode):
     aa.appendChild(a)
 
     frame_current = bpy.context.scene.frame_current
-    
+
     initial_location = mathutils.Vector((0, 0, 0))
     initial_rotation = mathutils.Quaternion((1, 0, 0, 0))
     initial_scale = mathutils.Vector((1, 1, 1))
@@ -119,9 +120,9 @@ def write_animation(ob, action, frame_start, frame_end, doc, xmlnode):
     frames = range(int(frame_start), int(frame_end) + 1)
 
     # If NODE_KEYFRAMES is True, then use only the keyframes to export the animation
-    #if config.get('NODE_KEYFRAMES'):
+    #if config.get('NODE_KEYFRAMES') is True:
     #    frames = get_keyframes(action)
-    
+
     for frame in frames:
 
         kf = doc.createElement('keyframe')

--- a/io_ogre/ogre/ogre_import.py
+++ b/io_ogre/ogre/ogre_import.py
@@ -221,7 +221,7 @@ def xCollectVertexData(data):
 
                 sys.stdout.write("\n")
 
-            if vb.hasAttribute('normals') and config.get('IMPORT_NORMALS'):
+            if vb.hasAttribute('normals') and config.get('IMPORT_NORMALS') is True:
                 for vertex in vb.getElementsByTagName('vertex'):
                     for vn in vertex.childNodes:
                         if vn.localName == 'normal':
@@ -684,7 +684,7 @@ def xReadAnimation(action, tracks):
                 continue
             time = float(keyframe.getAttribute('time'))
             frame = time * fps
-            if config.get('ROUND_FRAMES'):
+            if config.get('ROUND_FRAMES') is True:
                 frame = round(frame)
             for key in keyframe.childNodes:
                 if key.nodeType != 1:
@@ -809,7 +809,7 @@ def bCreateMesh(meshData, folder, name, filepath):
         subOb.select_set(True)
     
     # TODO: Try to merge everything into the armature object
-    if config.get('MERGE_SUBMESHES') == True:
+    if config.get('MERGE_SUBMESHES') is True:
         bpy.ops.object.join()
         ob = bpy.context.view_layer.objects.active
         ob.name = name
@@ -1297,7 +1297,7 @@ def load(filepath):
 
         # Use selected skeleton
         selectedSkeleton = bpy.context.active_object \
-            if (config.get('USE_SELECTED_SKELETON')
+            if (config.get('USE_SELECTED_SKELETON') is True
                 and bpy.context.active_object
                 and bpy.context.active_object.type == 'ARMATURE') else None
         if selectedSkeleton:
@@ -1320,9 +1320,9 @@ def load(filepath):
                     meshData['skeletonName'] = os.path.basename(skeletonFile[:-9])
 
                     # Parse animations
-                    if config.get('IMPORT_ANIMATIONS'):
+                    if config.get('IMPORT_ANIMATIONS') is True:
                         fps = xAnalyseFPS(xDocSkeletonData)
-                        if(fps and config.get('ROUND_FRAMES')):
+                        if(fps and (config.get('ROUND_FRAMES') is True)):
                             logger.info(" * Setting FPS to %s" % fps)
                             bpy.context.scene.render.fps = int(fps)
                         xCollectAnimations(meshData, xDocSkeletonData)
@@ -1335,7 +1335,7 @@ def load(filepath):
         xCollectMeshData(meshData, xDocMeshData, onlyName, folder)
         MaterialParser.xCollectMaterialData(meshData, onlyName, folder)
         
-        if config.get('IMPORT_SHAPEKEYS'):
+        if config.get('IMPORT_SHAPEKEYS') is True:
             xCollectPoseData(meshData, xDocMeshData)
 
         # After collecting is done, start creating stuff#
@@ -1343,7 +1343,7 @@ def load(filepath):
         bCreateMesh(meshData, folder, onlyName, pathMeshXml)
         bCreateAnimations(meshData)
 
-        if config.get('IMPORT_XML_DELETE') == True:
+        if config.get('IMPORT_XML_DELETE') is True:
             # Cleanup by deleting the XML file we created
             os.unlink("%s" % pathMeshXml)
             if 'skeleton' in meshData:

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -77,12 +77,12 @@ def dot_scene(path, scene_name=None):
     for ob in bpy.context.scene.objects:
         if ob.subcollision:
             continue
-        if not (config.get("EXPORT_HIDDEN") or ob in bpy.context.visible_objects):
+        if ((config.get("EXPORT_HIDDEN") is False) and (ob not in bpy.context.visible_objects)):
             continue
         if config.get("SELECTED_ONLY") and not ob.select_get():
-            if ob.type == 'CAMERA' and config.get("FORCE_CAMERA"):
+            if ob.type == 'CAMERA' and (config.get("FORCE_CAMERA") is True):
                 pass
-            elif ob.type == 'LIGHT' and config.get("FORCE_LIGHTS"):
+            elif ob.type == 'LIGHT' and (config.get("FORCE_LIGHTS") is True):
                 pass
             else:
                 continue
@@ -190,7 +190,7 @@ def dot_scene(path, scene_name=None):
             meshes.append(ob)
 
     materials = []
-    if config.get("MATERIALS"):
+    if config.get("MATERIALS") is True:
         logger.info("* Processing Materials")
         materials = util.objects_merge_materials(meshes)
 
@@ -223,7 +223,7 @@ def dot_scene(path, scene_name=None):
         )
 
     # Create the .scene file
-    if config.get('SCENE'):
+    if config.get('SCENE') is True:
         data = doc.toprettyxml()
         try:
             with open(target_scene_file, 'wb') as fd:
@@ -484,7 +484,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
     o = _ogre_node_helper( doc, ob )
     xmlparent.appendChild(o)
 
-    # if config.get('EXPORT_USER'):
+    # if config.get('EXPORT_USER') is True:
     # Custom user props
     if len(ob.items()) > 0:
         user = doc.createElement('userData')
@@ -534,13 +534,13 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         elif collisionFile:
             e.setAttribute('collisionFile', collisionFile )
 
-        #if config.get('EXPORT_USER'):
+        #if config.get('EXPORT_USER') is True:
         _mesh_entity_helper( doc, ob, e )
 
         # export mesh.xml file of this object
-        if config.get('MESH') and ob.data.name not in exported_meshes:
+        if (config.get('MESH') is True) and ob.data.name not in exported_meshes:
             exists = os.path.isfile( join( path, '%s.mesh' % ob.data.name ) )
-            overwrite = not exists or (exists and config.get("MESH_OVERWRITE"))
+            overwrite = not exists or (exists and (config.get("MESH_OVERWRITE") is True))
             tangents = int(config.get("GENERATE_TANGENTS"))
             mesh.dot_mesh(ob, path, overwrite=overwrite, tangents=tangents)
             exported_meshes.append( ob.data.name )
@@ -549,7 +549,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         # Deal with Array modifier
         vecs = [ ob.matrix_world.to_translation() ]
         for mod in ob.modifiers:
-            if config.get("ARRAY") == True and mod.type == 'ARRAY':
+            if (config.get("ARRAY") is True) and (mod.type == 'ARRAY'):
                 if mod.fit_type != 'FIXED_COUNT':
                     logger.warning("<%s> Unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
                     Report.warnings.append("Object \"%s\" has unsupported array-modifier type: %s, only 'Fixed Count' is supported" % (ob.name, mod.fit_type))
@@ -682,7 +682,7 @@ def dot_scene_node_export( ob, path, doc=None, rex=None,
         a.setAttribute('quadratic', '0.0')
 
     # Node Animation
-    if config.get('NODE_ANIMATION'):
+    if config.get('NODE_ANIMATION') is True:
         node_anim.dot_nodeanim(ob, doc, o)
 
     for child in ob.children:

--- a/io_ogre/ogre/skeleton.py
+++ b/io_ogre/ogre/skeleton.py
@@ -42,11 +42,11 @@ def dot_skeleton(obj, path, **kwargs):
     """
 
     arm = obj.find_armature()
-    if arm and config.get('ARMATURE_ANIMATION'):
+    if arm and (config.get('ARMATURE_ANIMATION') is True):
         exported_armatures = kwargs.get('exported_armatures')
 
         name = kwargs.get('force_name') or obj.data.name
-        if config.get('SHARED_ARMATURE') == True:
+        if config.get('SHARED_ARMATURE') is True:
             name = kwargs.get('force_name') or arm.data.name
         name = util.clean_object_name(name)
 
@@ -101,7 +101,7 @@ class Bone(object):
 
         self.bone = pbone        # safe to hold pointer to pose bone, not edit bone!
         self.shouldOutput = True
-        if config.get('ONLY_DEFORMABLE_BONES') and not pbone.bone.use_deform:
+        if (config.get('ONLY_DEFORMABLE_BONES') is True) and not pbone.bone.use_deform:
             self.shouldOutput = False
 
         # todo: Test -> #if pbone.bone.use_inherit_scale: logger.warn('Bone <%s> is using inherit scaling, Ogre has no support for this' % self.name)
@@ -131,7 +131,7 @@ class Bone(object):
         #else:
         #    self.pose_rotation = pbone.rotation_euler.to_quaternion()
             
-        if config.get('OGRE_INHERIT_SCALE'):
+        if config.get('OGRE_INHERIT_SCALE') is True:
             # special case workaround for broken Ogre nonuniform scaling:
             # Ogre can't deal with arbitrary nonuniform scaling, but it can handle certain special cases
             # The special case we are trying to handle here is when a bone has a nonuniform scale and it's
@@ -399,11 +399,11 @@ class Skeleton(object):
             if bone.shouldOutput:
                 bone_tracks.append( Bone_Track(bone) )
             bone.clear_pose_transform()  # clear out any leftover pose transforms in case this bone isn't keyframed
-        
+
         # Decide keyframes to export:
         # ONLY keyframes (Exported animation won't be affected by Inverse Kinematics, Drivers and modified F-Curves)
         # OR export keyframe each frame over animation range (Exported animation will be affected by Inverse Kinematics, Drivers and modified F-Curves)
-        if config.get('ONLY_KEYFRAMES'): # Only keyframes 
+        if config.get('ONLY_KEYFRAMES') is True: # Only keyframes
             frame_range = [] # Holds a list of keyframes for export
             action = bpy.data.actions[actionName] # actionName is the animation name (NLAtrack child)
             # loops through all channels on the f-curve --> Code taken from: https://blender.stackexchange.com/questions/8387/how-to-get-keyframe-data-from-python
@@ -443,14 +443,14 @@ class Skeleton(object):
         parentElement.appendChild( anim )
         tracks = doc.createElement('tracks')
         anim.appendChild( tracks )
-        
+
         # Report and log
         suffix_text = ''
-        if config.get('ONLY_KEYFRAMES'):
+        if config.get('ONLY_KEYFRAMES') is True:
             suffix_text = ' - Key frames: ' + str(frame_range)
             logger.info('+ %s Key frames: %s' %(actionName,str(frame_range)))            
         Report.armature_animations.append( '%s : %s [start frame=%s end frame=%s]%s' %(arm.name, actionName, frameBegin, frameEnd, suffix_text) )
-            
+
         # Write stuff to skeleton.xml file
         anim.setAttribute('name', actionName)   # USE the action name
         anim.setAttribute('length', '%6f' %( (frameEnd - frameBegin)/ _fps ) )
@@ -519,9 +519,9 @@ class Skeleton(object):
                 Report.warnings.append('You must assign an NLA strip to armature (%s) that defines the start and end frames' % arm.name)
 
             # Log to console
-            if config.get('ONLY_KEYFRAMES'):
+            if config.get('ONLY_KEYFRAMES') is True:
                 logger.info('+ Only exporting keyframes')
-                            
+
             actions = {}  # actions by name
             # the only thing NLA is used for is to gather the names of the actions
             # it doesn't matter if the actions are all in the same NLA track or in different tracks
@@ -543,7 +543,7 @@ class Skeleton(object):
                 action = actionData[0]
                 arm.animation_data.action = action  # set as the current action
                 suppressedBones = []
-                if config.get('ONLY_KEYFRAMED_BONES'):
+                if config.get('ONLY_KEYFRAMED_BONES') is True:
                     keyframedBones = {}
                     for group in action.groups:
                         keyframedBones[ group.name ] = True

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -174,7 +174,7 @@ class _OgreCommonExport_(object):
         file_handler = None
 
         # Add a file handler to all Logger instances
-        if config.get('ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') is True:
             log_file = ("%s/blender2ogre.log" % target_path)
             logger.info("* Writing log file to: %s" % log_file)
 
@@ -191,7 +191,7 @@ class _OgreCommonExport_(object):
 
                 file_handler.setFormatter(file_formatter)
 
-                if config.get('DEBUG_LOGGING') == True:
+                if config.get('DEBUG_LOGGING') is True:
                     level = logging.DEBUG
                 else:
                     level = logging.INFO
@@ -220,7 +220,7 @@ class _OgreCommonExport_(object):
         Report.show()
 
         # Flush and close all logging file handlers
-        if config.get('ENABLE_LOGGING') == True and file_handler != None:
+        if config.get('ENABLE_LOGGING') is True and file_handler is not None:
             for logger_name in logging.Logger.manager.loggerDict.keys():
                 logging.getLogger(logger_name).handlers.clear()
 

--- a/io_ogre/ui/importer.py
+++ b/io_ogre/ui/importer.py
@@ -165,17 +165,17 @@ class _OgreCommonImport_(object):
         target_file_name_no_ext = os.path.splitext(target_file_name)[0]
 
         file_handler = None
-        
+
         # Add a file handler to all Logger instances
-        if config.get('ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') is True:
             log_file = ("%s/blender2ogre.log" % target_path)
             logger.info("Writing log file to: %s" % log_file)
 
             file_handler = logging.FileHandler(filename=log_file, mode='w', encoding='utf-8', delay=False)
-            
+
             # Show the python file name from where each log message originated
             SHOW_LOG_NAME = False
-            
+
             if SHOW_LOG_NAME:
                 file_formatter = logging.Formatter(fmt='%(asctime)s %(name)9s.py [%(levelname)5s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
             else:
@@ -194,13 +194,13 @@ class _OgreCommonImport_(object):
         Report.show()
 
         # Flush and close all logging file handlers
-        if config.get('ENABLE_LOGGING') == True:
+        if config.get('ENABLE_LOGGING') is True:
             for logger_name in logging.Logger.manager.loggerDict.keys():
                 logger_instance = logging.getLogger(logger_name)
-                    
+
                 # Remove handlers
                 logger_instance.handlers.clear()
-            
+
             file_handler.flush()
             file_handler.close()
 

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -107,7 +107,7 @@ def mesh_upgrade_tool(infile):
         if config.get('LOD_GENERATION') == '0':
             Report.warnings.append("OgreMeshUpgrader failed, LODs will not be generated for this mesh: %s" % filename)
 
-        if config.get('GENERATE_EDGE_LISTS') == True:
+        if config.get('GENERATE_EDGE_LISTS') is True:
             Report.warnings.append("OgreMeshUpgrader failed, Edge Lists will not be generated for this mesh: %s" % filename)
 
         return
@@ -139,7 +139,7 @@ def mesh_upgrade_tool(infile):
         cmd.append(str(config.get('LOD_PERCENT')))
 
     # Don't generate Edge Lists (-e = DON'T generate edge lists (for stencil shadows))
-    if config.get('GENERATE_EDGE_LISTS') == False:
+    if config.get('GENERATE_EDGE_LISTS') is False:
         cmd.append('-e')
 
     # Put logfile into output directory
@@ -158,7 +158,7 @@ def mesh_upgrade_tool(infile):
     if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
         logger.info("* Generating %s LOD levels for mesh: %s" % (config.get('LOD_LEVELS'), filename))
 
-    if config.get('GENERATE_EDGE_LISTS') == True:
+    if config.get('GENERATE_EDGE_LISTS') is True:
         logger.info("* Generating Edge Lists for mesh: %s" % filename)
 
     # First try to execute with the -log option
@@ -177,7 +177,7 @@ def mesh_upgrade_tool(infile):
         if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
             Report.warnings.append("OgreMeshUpgrader failed, LODs will not be generated for this mesh: %s" % filename)
 
-        if config.get('GENERATE_EDGE_LISTS') == True:
+        if config.get('GENERATE_EDGE_LISTS') is True:
             Report.warnings.append("OgreMeshUpgrader failed, Edge Lists will not be generated for this mesh: %s" % filename)
 
         if error != None:
@@ -187,7 +187,7 @@ def mesh_upgrade_tool(infile):
         if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
             logger.info("- Generated %s LOD levels for mesh: %s" % (config.get('LOD_LEVELS'), filename))
 
-        if config.get('GENERATE_EDGE_LISTS') == True:
+        if config.get('GENERATE_EDGE_LISTS') is True:
             logger.info("- Generated Edge Lists for mesh: %s" % filename)
 
 
@@ -257,7 +257,7 @@ def mesh_convert(infile):
         
     else:
         # Convert to v2 format if required
-        cmd.append('-%s' %config.get('MESH_TOOL_VERSION'))
+        cmd.append('-%s' % config.get('MESH_TOOL_VERSION'))
 
         # Finally, specify input file
         cmd.append(infile)
@@ -271,7 +271,7 @@ def mesh_convert(infile):
 
         # Open log file to replace old logging feature that the new tool dropped
         # The log file will be created alongside the exported mesh
-        if config.get('ENABLE_LOGGING'):
+        if config.get('ENABLE_LOGGING') is True:
             logfile_path, name = os.path.split(infile)
             logfile = os.path.join(logfile_path, 'OgreMeshTool.log')
         
@@ -311,7 +311,7 @@ def xml_convert(infile, has_uvs=False):
 
     # OgreMeshTool (OGRE v2): -e = DON'T generate edge lists (for stencil shadows)
     # OgreXMLConverter (OGRE < 1.10): -e = DON'T generate edge lists (for stencil shadows)
-    if config.get('GENERATE_EDGE_LISTS') == False and (version < (1,10,0) or converter_type == "OgreMeshTool"):
+    if config.get('GENERATE_EDGE_LISTS') is False and (version < (1,10,0) or converter_type == "OgreMeshTool"):
         cmd.append('-e')
 
     if config.get('GENERATE_TANGENTS') != "0" and converter_type == "OgreMeshTool":
@@ -323,7 +323,7 @@ def xml_convert(infile, has_uvs=False):
         cmd.append('-O')
         cmd.append(config.get('OPTIMISE_VERTEX_BUFFERS_OPTIONS'))
 
-    if not config.get('OPTIMISE_ANIMATIONS'):
+    if config.get('OPTIMISE_ANIMATIONS') is not True:
         cmd.append('-o')
 
     if converter_type == "OgreXMLConverter":
@@ -353,13 +353,13 @@ def xml_convert(infile, has_uvs=False):
             Report.errors.append("OgreXMLConverter finished with non-zero status converting mesh: (%s), it might not have been properly generated" % name)
 
         # Clean up .xml file after successful conversion
-        if proc.returncode == 0 and config.get('EXPORT_XML_DELETE') == True:
+        if (proc.returncode == 0) and (config.get('EXPORT_XML_DELETE') is True):
             logger.info("Removing generated xml file after conversion: %s" % infile)
             os.remove(infile)
 
     else:
         # Convert to v2 format if required
-        cmd.append('-%s' %config.get('MESH_TOOL_VERSION'))
+        cmd.append('-%s' % config.get('MESH_TOOL_VERSION'))
 
         # If requested by the user, generate LOD levels through OgreMeshUpgrader/OgreMeshTool
         if config.get('LOD_LEVELS') > 0 and config.get('LOD_GENERATION') == '0':
@@ -387,7 +387,7 @@ def xml_convert(infile, has_uvs=False):
 
         # Open log file to replace old logging feature that the new tool dropped
         # The log file will be created alongside the exported mesh
-        if config.get('ENABLE_LOGGING'):
+        if config.get('ENABLE_LOGGING') is True:
             logfile_path, name = os.path.split(infile)
             logfile = os.path.join(logfile_path, 'OgreMeshTool.log')
 
@@ -401,7 +401,7 @@ def xml_convert(infile, has_uvs=False):
             Report.errors.append("OgreMeshTool finished with non-zero status converting mesh: (%s), it might not have been properly generated" % name)
 
         # Clean up .xml file after successful conversion
-        if proc.returncode == 0 and config.get('EXPORT_XML_DELETE') == True:
+        if (proc.returncode == 0) and (config.get('EXPORT_XML_DELETE') is True):
             logger.info("Removing generated xml file after conversion: %s" % infile)
             os.remove(infile)
 
@@ -465,9 +465,9 @@ def find_bone_index( ob, arm, groupidx): # sometimes the groups are out of order
     if groupidx < len(ob.vertex_groups): # reported by Slacker
         vg = ob.vertex_groups[ groupidx ]
         j = 0
-        for i,bone in enumerate(arm.pose.bones):
-            if not bone.bone.use_deform and config.get('ONLY_DEFORMABLE_BONES'):
-                j+=1 # if we skip bones we need to adjust the id
+        for i, bone in enumerate(arm.pose.bones):
+            if (config.get('ONLY_DEFORMABLE_BONES') is True) and (bone.bone.use_deform is False):
+                j = j + 1 # if we skip bones we need to adjust the id
             if bone.name == vg.name:
                 return i-j
     else:


### PR DESCRIPTION
The issue is that `config.get()` can return any kind of value, not just `True` or `False`, so we need to check if the return value *is*  `True` or `False` the truthiness comparison does not work.