### PR TITLE
From Blender 2.8x+ on `LAMPS` are now called `LIGHTS`

### DIFF
--- a/io_ogre/config.py
+++ b/io_ogre/config.py
@@ -43,7 +43,7 @@ _CONFIG_DEFAULTS_ALL = {
     'EXPORT_HIDDEN' : True,
     #'EXPORT_USER' : True,
     'FORCE_CAMERA' : True,
-    'FORCE_LAMPS' : True,
+    'FORCE_LIGHTS' : True,
     'NODE_ANIMATION' : True,
     #'NODE_KEYFRAMES' : False,
 

--- a/io_ogre/ogre/scene.py
+++ b/io_ogre/ogre/scene.py
@@ -82,7 +82,7 @@ def dot_scene(path, scene_name=None):
         if config.get("SELECTED_ONLY") and not ob.select_get():
             if ob.type == 'CAMERA' and config.get("FORCE_CAMERA"):
                 pass
-            elif ob.type == 'LAMP' and config.get("FORCE_LAMPS"):
+            elif ob.type == 'LIGHT' and config.get("FORCE_LIGHTS"):
                 pass
             else:
                 continue

--- a/io_ogre/ui/__init__.py
+++ b/io_ogre/ui/__init__.py
@@ -44,7 +44,7 @@ def update_meshpreview_button_visibility(show):
             if meshpreviewButtonDisplayed:
                 bpy.types.VIEW3D_PT_tools_active.remove(add_preview_button)
                 meshpreviewButtonDisplayed = False
-                
+
     elif not show and meshpreviewButtonDisplayed:
         bpy.types.VIEW3D_PT_tools_active.remove(add_preview_button)
         meshpreviewButtonDisplayed = False

--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -104,7 +104,7 @@ class _OgreCommonExport_(object):
         # Options associated with each section
         section_options = {
             "General" : ["EX_SWAP_AXIS", "EX_V2_MESH_TOOL_VERSION", "EX_EXPORT_XML_DELETE"],
-            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_FORCE_CAMERA", "EX_FORCE_LAMPS", "EX_NODE_ANIMATION"],
+            "Scene" : ["EX_SCENE", "EX_SELECTED_ONLY", "EX_EXPORT_HIDDEN", "EX_FORCE_CAMERA", "EX_FORCE_LIGHTS", "EX_NODE_ANIMATION"],
             "Materials" : ["EX_MATERIALS", "EX_SEPARATE_MATERIALS", "EX_COPY_SHADER_PROGRAMS", "EX_USE_FFP_PARAMETERS"],
             "Textures" : ["EX_DDS_MIPS", "EX_FORCE_IMAGE_FORMAT"],
             "Armature" : ["EX_ARMATURE_ANIMATION", "EX_SHARED_ARMATURE", "EX_ONLY_KEYFRAMES", "EX_ONLY_DEFORMABLE_BONES", "EX_ONLY_KEYFRAMED_BONES", "EX_OGRE_INHERIT_SCALE", "EX_TRIM_BONE_WEIGHTS"],
@@ -223,7 +223,7 @@ class _OgreCommonExport_(object):
         if config.get('ENABLE_LOGGING') == True and file_handler != None:
             for logger_name in logging.Logger.manager.loggerDict.keys():
                 logging.getLogger(logger_name).handlers.clear()
-            
+
             file_handler.flush()
             file_handler.close()
 
@@ -277,12 +277,12 @@ class _OgreCommonExport_(object):
     #    default=config.get('EXPORT_USER')) = {}
     EX_FORCE_CAMERA : BoolProperty(
         name="Force Camera",
-        description="Export active camera",
+        description="Export active camera, even if not selected",
         default=config.get('FORCE_CAMERA')) = {}
-    EX_FORCE_LAMPS : BoolProperty(
-        name="Force Lamps",
-        description="Export all Lamps",
-        default=config.get('FORCE_LAMPS')) = {}
+    EX_FORCE_LIGHTS : BoolProperty(
+        name="Force Lights",
+        description="Export all Lights, even if not selected",
+        default=config.get('FORCE_LIGHTS')) = {}
     EX_NODE_ANIMATION : BoolProperty(
         name="Export Node Animations",
         description="Export Node Animations, these are animations of the objects properties like position, rotation and scale",
@@ -294,7 +294,7 @@ class _OgreCommonExport_(object):
 #Don't select this option if you have any fine tuning of the F-Curves in Blender, since they won't get exported.
 #NOTE: Node Animations based on the 'Follow Path' constraint will most likely fail with this option set to True.""",
 #        default=config.get('NODE_KEYFRAMES')) = {}
-    
+
     # Materials
     EX_MATERIALS : BoolProperty(
         name="Export Materials",
@@ -324,7 +324,7 @@ class _OgreCommonExport_(object):
         name="Convert Images",
         description="Convert all textures to selected image format",
         default=config.get('FORCE_IMAGE_FORMAT')) = {}
-    
+
     # Armature
     EX_ARMATURE_ANIMATION : BoolProperty(
         name="Armature Animation",

--- a/io_ogre/util.py
+++ b/io_ogre/util.py
@@ -700,8 +700,9 @@ def wordwrap( txt ):
 def get_lights_by_type( T ):
     r = []
     for ob in bpy.context.scene.objects:
-        if ob.type=='LAMP':
-            if ob.data.type==T: r.append( ob )
+        if ob.type == 'LIGHT':
+            if ob.data.type == T:
+                r.append( ob )
     return r
 
 invalid_chars_in_name     = '"<>\:' # "<> is xml prohibited, : is Ogre prohibited, \ is standard escape char


### PR DESCRIPTION
There was an oversight in the transition from Blender 2.7x to 2.8x+ which made the option `FORCE_LAMPS` unusable.
