### PR TITLE
create default material if it could not be imported

### DIFF
--- a/io_ogre/ogre/ogre_import.py
+++ b/io_ogre/ogre/ogre_import.py
@@ -1270,6 +1270,9 @@ def bCreateSubMeshes(meshData, meshName):
         else:
             logger.warning("Definition of material: \"%s\" not found!" % subMeshName)
             Report.warnings.append("Definition of material: \"%s\" not found!" % subMeshName)
+            # create default material if it could not be imported to preserve submesh material reference
+            mat = bpy.data.materials.new(name=subMeshName)
+            ob.data.materials.append(mat)
 
         # Texture coordinates
         if 'texcoordsets' in geometry and 'uvsets' in geometry:


### PR DESCRIPTION
create default material if it could not be imported to preserve submesh material reference.

https://github.com/OGRECave/blender2ogre/issues/156#issuecomment-2061652270