### PR TITLE
workaround alpha blending for blender 4.2

### DIFF
--- a/io_ogre/ogre/material.py
+++ b/io_ogre/ogre/material.py
@@ -194,7 +194,7 @@ class OgreMaterialGenerator(object):
             if mat.blend_method == "CLIP":
                 alpha = mat_wrapper.alpha
                 self.w.iword('alpha_rejection greater_equal').round(255*mat.alpha_threshold).nl()
-            elif mat.blend_method != "OPAQUE":
+            elif mat.blend_method == "BLEND":
                 alpha = mat_wrapper.alpha
                 self.w.iword('scene_blend alpha_blend').nl()
                 if mat.show_transparent_back:

--- a/io_ogre/ogre/materialv2json.py
+++ b/io_ogre/ogre/materialv2json.py
@@ -212,7 +212,7 @@ class OgreMaterialv2JsonGenerator(object):
             pass
         elif material.blend_method == "CLIP":     # CLIP enables alpha_test (alpha rejection)
             datablock["alpha_test"] = ["greater_equal", material.alpha_threshold, False]
-        elif material.blend_method in ["HASHED", "BLEND"]: 
+        elif material.blend_method == "BLEND": 
             datablock["transparency"] = {
                 "mode": "Transparent",        
                 "use_alpha_from_textures": tex_filename != None,  # DEFAULT


### PR DESCRIPTION
fixes #251

@sercero thats my poor attempt at detecting opaque surfaces, without really knowing the bpy API.