### PR TITLE
Fix `_OgreCommonExport_.converter` not initialized on Blender 4.4.

### DIFF
--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -35,15 +35,19 @@ def menu_func(self, context):
 class _OgreCommonExport_(object):
 
     called_from_UI = False
+    converter = "unknown"
 
     @classmethod
     def poll(cls, context):
         if context.active_object and context.mode != 'EDIT_MESH':
             return True
 
-    def __init__(self):
-        # Check that converter is setup
-        self.converter = detect_converter_type()
+    # https://docs.blender.org/api/current/bpy.utils.html#bpy.utils.register_class
+    # > If the class has a register class method it will be called before registration.
+    # call chain: __init__.py::register() -> bpy.utils.register_class() -> (Blender internals) -> Self::register()
+    @classmethod
+    def register(cls):
+       cls.converter = detect_converter_type()
 
     def invoke(self, context, event):
         # Update the interface with the config values


### PR DESCRIPTION
Blender 4.4 release notes say nothing about addon API change, but I am experiencing
```
Traceback (most recent call last):
  File "/home/richardn/.config/blender/4.4/scripts/addons/io_ogre/ui/export.py", line 78, in draw
    if self.converter == "unknown":
       ^^^^^^^^^^^^^^
  File "/usr/share/blender/4.4/scripts/modules/bpy_types.py", line 940, in __getattribute__
    return super().__getattribute__(attr)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
AttributeError: 'OP_ogre_export' object has no attribute 'converter'
```
after upgrading to 4.4 (Error triggered when opening the export dialog, and due to the error no export settings widget will be shown, and export will fail dramatically).

After some investigation I am still confused why old code broke (instantiation should have happened before `.draw()` is called?), but what I changed here respects what is written in Blender API docs, and fixes the problem I bumped into.