### PR TITLE
Update/crash fix for Blender 4.4

### DIFF
--- a/io_ogre/ui/export.py
+++ b/io_ogre/ui/export.py
@@ -499,3 +499,7 @@ class OP_ogre_export(bpy.types.Operator, _OgreCommonExport_):
     bl_label = "Export Ogre"
     bl_options = {'REGISTER'}
     # export logic is contained in the subclass
+
+    def __init__(self, *args, **kwargs):
+        bpy.types.Operator.__init__(self, *args, **kwargs)
+        _OgreCommonExport_.__init__(self)


### PR DESCRIPTION
When trying to export on Blender 4.4, it crashes in this file (shown in the system console) and then has no UI in the export dialogue.

This commit fixes that and with this fix it works to export in Blender 4.4 successfully.

See more about why this is needed here:
https://developer.blender.org/docs/release_notes/4.4/python_api/