### PR TITLE
Update importer.py

### DIFF
--- a/io_ogre/ui/importer.py
+++ b/io_ogre/ui/importer.py
@@ -348,3 +348,7 @@ class OP_ogre_import(bpy.types.Operator, _OgreCommonImport_):
     bl_label = "Import Ogre"
     bl_options = {'REGISTER'}
     # import logic is contained in the subclass
+
+    def __init__(self, *args, **kwargs):
+        bpy.types.Operator.__init__(self, *args, **kwargs)
+        _OgreCommonImport_.__init__(self)


### PR DESCRIPTION
you forgot to put  ```def __init__(self, *args, **kwargs):
        bpy.types.Operator.__init__(self, *args, **kwargs)
        _OgreCommonExport_.__init__(self)``` to this file, without it the import ui is invisible.